### PR TITLE
Update vowpal_wabbit submodule

### DIFF
--- a/build-windows.cmd
+++ b/build-windows.cmd
@@ -5,14 +5,16 @@ for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio
   set InstallDir=%%i
 )
 
-if not exist "%InstallDir%\MSBuild\15.0\Bin\MSBuild.exe" (
-  echo ERROR: MsBuild couldn't be found
-  exit /b 1
-)
-
-if not defined VcpkgInstallRoot (
-  echo ERROR: VcpkgInstallRoot must be set
-  exit /b 1
+REM Enable injecting of msbuild path (rather than relying on an installed version of Visual Studio),
+REM but fallback to detection path if not provided.
+if not defined msBuildPath (
+  if not exist "%InstallDir%\MSBuild\15.0\Bin\MSBuild.exe" (
+    echo ERROR: MsBuild couldn't be found
+    exit /b 1
+  )
+  else (
+    SET "msBuildPath=%InstallDir%\MSBuild\15.0\Bin\MSBuild.exe"
+  )
 )
 
 call "%InstallDir%\Common7\Tools\VsDevCmd.bat"
@@ -29,7 +31,6 @@ nuget install -o packages ext_libs\vowpal_wabbit\vowpalwabbit\packages.config
 nuget install -o packages bindings\cs\rl.net.native\packages.config
 nuget install -o packages rlclientlib\packages.config
 nuget install -o packages unit_tests\packages.config
-
 
 dotnet restore rl.sln
 

--- a/rlclientlib/vw_model/safe_vw.cc
+++ b/rlclientlib/vw_model/safe_vw.cc
@@ -3,6 +3,7 @@
 // VW headers
 #include "example.h"
 #include "parse_example_json.h"
+#include "parser.h"
 
 namespace reinforcement_learning {
 
@@ -85,7 +86,6 @@ namespace reinforcement_learning {
 
     // cleanup VW instance
     reset_source(*_vw, _vw->num_bits);
-    release_parser_datastructures(*_vw);
 
     VW::finish(*_vw);
   }


### PR DESCRIPTION
Pulls in these fixes
- fac3c061 Fix crash when empty multi_ex is supplied for --cb_explore_adf (VowpalWabbit/vowpal_wabbit#1679)
- f085178d bugfix:  cb_adf is not including some examples in stats calculation (VowpalWabbit/vowpal_wabbit#1686)
- c9d9af7c Fix memory leak in cb_explore_adf (VowpalWabbit/vowpal_wabbit#1698)
- 1e8742b4 Fix some VW initialization memory leaks (VowpalWabbit/vowpal_wabbit#1697)
- 75423e32 Fix best constant and best constant's loss calculation when using ksvm (VowpalWabbit/vowpal_wabbit#1704)
- 2b64c3c0 Use std::exp instead of exp free function (VowpalWabbit/vowpal_wabbit#1709)
- 6b7b1605 Fix unused params warnings plus incomplete struct init (done to default values). (VowpalWabbit/vowpal_wabbit#1710)
- 2e1602d6 Compile fixes (VowpalWabbit/vowpal_wabbit#1713)
- b50fb597 Make cbify reduction respect is_learn parameter (VowpalWabbit/vowpal_wabbit#1722)
- b9491ddf Fix a small issue and cleanup usage of long long (VowpalWabbit/vowpal_wabbit#1733)
- 6dd314d2 Fix model file parser for proper treatment of negative-valued options (VowpalWabbit/vowpal_wabbit#1742)

This also includes the option parsing changes
- b8ab3969 `options_i` command line parsing refactor  (VowpalWabbit/vowpal_wabbit#1706)
- 5b020c4d Ataymano/mac options types fix (VowpalWabbit/vowpal_wabbit#1718)

There are other small or non-rl-consumable changes