### PR TITLE
Split build pipeline into per-stage scripts

### DIFF
--- a/.scripts/build.cmd
+++ b/.scripts/build.cmd
@@ -1,0 +1,22 @@
+@ECHO OFF
+IF DEFINED DebugBuildScripts (
+    @ECHO ON
+)
+
+SETLOCAL
+
+CALL %~dp0init.cmd
+PUSHD %~dp0
+
+REM It seems like the build needs to happen in rlRoot, though I am not super-sure why that is.
+PUSHD %rlRoot% 
+
+REM TODO: Figure out how to parametrize this script?! (is there a standard, or do we actually need parse args?)
+ECHO Building "%rlRoot%\rl.sln" for Release x64
+"%msbuildPath%" /verbosity:normal /m /p:Configuration=Release;Platform=x64 "%rlRoot%\rl.sln"
+
+POPD
+
+POPD
+
+ENDLOCAL

--- a/.scripts/init.cmd
+++ b/.scripts/init.cmd
@@ -12,8 +12,7 @@ IF NOT DEFINED msbuildPath (
     if not exist "%InstallDir%\MSBuild\15.0\Bin\MSBuild.exe" (
         echo ERROR: MsBuild couldn't be found
         exit /b 1
-    )
-    else (
+    ) else (
         SET "msBuildPath=%InstallDir%\MSBuild\15.0\Bin\MSBuild.exe"
     )
 )

--- a/.scripts/init.cmd
+++ b/.scripts/init.cmd
@@ -1,0 +1,49 @@
+REM Integration points for toolchain customization
+IF NOT DEFINED nugetPath (
+    SET nugetPath=nuget
+)
+
+IF NOT DEFINED msbuildPath (
+    REM Try to find VS Install
+    for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.Component.MSBuild -property installationPath`) do (
+        set InstallDir=%%i
+    )
+
+    if not exist "%InstallDir%\MSBuild\15.0\Bin\MSBuild.exe" (
+        echo ERROR: MsBuild couldn't be found
+        exit /b 1
+    )
+    else (
+        SET "msBuildPath=%InstallDir%\MSBuild\15.0\Bin\MSBuild.exe"
+    )
+)
+
+IF NOT DEFINED dotnetPath (
+    SET dotnetPath=dotnet
+)
+
+IF NOT DEFINED vcpkgPath (
+    IF NOT DEFINED VcpkgInstallRoot (
+        ECHO ERROR: vcpkgPath is not configured, but VcpkgInstallRoot is also not configured. Cannot find vcpkg.
+        EXIT /b 1
+    )
+
+    SET "vcpkgPath=%VcpkgInstallRoot%vcpkg.exe"
+    SET "VcpkgIntegration=%VcpkgInstallRoot%scripts\buildsystems\msbuild\vcpkg.targets"
+)
+
+REM The correct way to integrate this is to use msbuild targets and contribute them back to flatbuff, 
+REM rather than a command line execution
+IF NOT DEFINED flatcPath (
+    IF NOT DEFINED VcpkgInstallRoot (
+        ECHO ERROR: flatcPath is not configured, but VcpkgInstallRoot is also not configured. Cannot find vcpkg.
+        EXIT /b 1
+    )
+
+    SET "flatcPath=%VcpkgInstallRoot%installed\x64-windows\tools\flatbuffers\flatc.exe"
+)
+
+REM Repo-specific paths
+IF NOT DEFINED rlRoot (
+    SET rlRoot=%~dp0..
+)

--- a/.scripts/restore.cmd
+++ b/.scripts/restore.cmd
@@ -13,7 +13,9 @@ PUSHD %~dp0
 
 REM TODO: This really should be out-of-source (also, can we switch to vcpkg for these?)
 ECHO Restoring "%rlRoot%\ext_libs\vowpal_wabbit\vowpalwabbit\packages.config"
-"%nugetPath%" install "%rlRoot%\ext_libs\vowpal_wabbit\vowpalwabbit\packages.config" -solutionDir "%rlRoot%\"
+
+REM Do not remove the space at the end of the "solutionDir" specifier, as otherwise it breaks NuGet
+"%nugetPath%" install -o packages "%rlRoot%\ext_libs\vowpal_wabbit\vowpalwabbit\packages.config" -solutionDir "%rlRoot%\ "
 ECHO.
 
 ECHO Restoring "%rlRoot%\bindings\cs\rl.net.native\packages.config"

--- a/.scripts/restore.cmd
+++ b/.scripts/restore.cmd
@@ -1,0 +1,41 @@
+@ECHO OFF
+IF DEFINED DebugBuildScripts (
+    @ECHO ON
+)
+
+SETLOCAL
+
+CALL %~dp0init.cmd
+PUSHD %~dp0
+
+%vcpkgPath% install cpprestsdk:x64-windows
+%vcpkgPath% install flatbuffers:x64-windows
+
+REM TODO: This really should be out-of-source (also, can we switch to vcpkg for these?)
+ECHO Restoring "%rlRoot%\ext_libs\vowpal_wabbit\vowpalwabbit\packages.config"
+"%nugetPath%" install "%rlRoot%\ext_libs\vowpal_wabbit\vowpalwabbit\packages.config" -solutionDir "%rlRoot%\"
+ECHO.
+
+ECHO Restoring "%rlRoot%\bindings\cs\rl.net.native\packages.config"
+"%nugetPath%" install -o packages "%rlRoot%\bindings\cs\rl.net.native\packages.config"
+ECHO.
+
+ECHO Restoring "%rlRoot%\ext_libs\vowpal_wabbit\vowpalwabbit\packages.config"
+"%nugetPath%" install -o packages "%rlRoot%\rlclientlib\packages.config"
+ECHO.
+
+ECHO Restoring "%rlRoot%\ext_libs\vowpal_wabbit\vowpalwabbit\packages.config"
+"%nugetPath%" install -o packages "%rlRoot%\unit_tests\packages.config"
+ECHO.
+
+ECHO Restoring SDK-Style projects in "%rlRoot%\rl.sln"
+%dotnetPath% restore "%rlRoot%\rl.sln"
+ECHO.
+
+REM TODO: Is this still necessary?
+SET PATH=%PATH%;%VcpkgInstallRoot%installed\x64-windows\tools\flatbuffers
+
+
+POPD
+
+ENDLOCAL

--- a/.scripts/restore.cmd
+++ b/.scripts/restore.cmd
@@ -15,19 +15,19 @@ REM TODO: This really should be out-of-source (also, can we switch to vcpkg for 
 ECHO Restoring "%rlRoot%\ext_libs\vowpal_wabbit\vowpalwabbit\packages.config"
 
 REM Do not remove the space at the end of the "solutionDir" specifier, as otherwise it breaks NuGet
-"%nugetPath%" install -o packages "%rlRoot%\ext_libs\vowpal_wabbit\vowpalwabbit\packages.config" -solutionDir "%rlRoot%\ "
+"%nugetPath%" install -o "%rlRoot%\packages" "%rlRoot%\ext_libs\vowpal_wabbit\vowpalwabbit\packages.config" -solutionDir "%rlRoot%\ "
 ECHO.
 
 ECHO Restoring "%rlRoot%\bindings\cs\rl.net.native\packages.config"
-"%nugetPath%" install -o packages "%rlRoot%\bindings\cs\rl.net.native\packages.config"
+"%nugetPath%" install -o "%rlRoot%\packages" "%rlRoot%\bindings\cs\rl.net.native\packages.config"
 ECHO.
 
-ECHO Restoring "%rlRoot%\ext_libs\vowpal_wabbit\vowpalwabbit\packages.config"
-"%nugetPath%" install -o packages "%rlRoot%\rlclientlib\packages.config"
+ECHO Restoring "%rlRoot%\rlclientlib\packages.config"
+"%nugetPath%" install -o "%rlRoot%\packages" "%rlRoot%\rlclientlib\packages.config"
 ECHO.
 
-ECHO Restoring "%rlRoot%\ext_libs\vowpal_wabbit\vowpalwabbit\packages.config"
-"%nugetPath%" install -o packages "%rlRoot%\unit_tests\packages.config"
+ECHO Restoring "%rlRoot%\unit_tests\packages.config"
+"%nugetPath%" install -o "%rlRoot%\packages" "%rlRoot%\unit_tests\packages.config"
 ECHO.
 
 ECHO Restoring SDK-Style projects in "%rlRoot%\rl.sln"

--- a/.scripts/test.cmd
+++ b/.scripts/test.cmd
@@ -1,0 +1,22 @@
+@ECHO OFF
+IF DEFINED DebugBuildScripts (
+    @ECHO ON
+)
+
+SETLOCAL
+
+CALL %~dp0init.cmd
+
+PUSHD %rlRoot%
+
+REM TODO: Determine how to pass test failure out of this script so it can be used by CI/CD setups
+
+ECHO Running RL Unit Tests
+"%rlRoot%\x64\Release\unit_test.exe"
+
+ECHO Running RL.Net Unit Tests
+REM %vstestPath% /Platform:x64 /inIsolation "%vwRoot%\vowpalwabbit\x64\Release\cs_unittest.dll" /TestCaseFilter:"TestCategory!=NotOnVSO"
+
+POPD
+
+ENDLOCAL

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,11 @@ configuration: Release
 platform: x64
 clone_folder: c:\reinforcement_learning\
 cache:
-  - c:\tools\vcpkg\installed\ -> build-windows.cmd
-  - packages -> **\packages.config, build-windows.cmd
+  - c:\tools\vcpkg\installed\ -> build-windows.cmd, .scripts\restore.cmd
+  - packages -> **\packages.config, build-windows.cmd, .scripts\restore.cmd
 environment:
   VcpkgInstallRoot: c:\tools\vcpkg\
+  rlRoot: C:\reinforcement_learning
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
 install:
   - git submodule update --init --recursive
@@ -18,4 +19,4 @@ build_script:
   - cd c:\reinforcement_learning
   - .\build-windows.cmd
 test_script:
-  - c:\reinforcement_learning\x64\Release\unit_test.exe
+  - .scripts\test.cmd

--- a/build-windows.cmd
+++ b/build-windows.cmd
@@ -1,11 +1,11 @@
 @echo off
 setlocal
 
-.scripts\init.cmd
+CALL .scripts\init.cmd
 
 REM TODO: Is this necessary?
 call "%InstallDir%\Common7\Tools\VsDevCmd.bat"
 
-.scripts\restore.cmd
+CALL .scripts\restore.cmd
 
-.scripts\build.cmd
+CALL .scripts\build.cmd

--- a/build-windows.cmd
+++ b/build-windows.cmd
@@ -1,37 +1,11 @@
 @echo off
 setlocal
 
-for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.Component.MSBuild -property installationPath`) do (
-  set InstallDir=%%i
-)
+.scripts\init.cmd
 
-REM Enable injecting of msbuild path (rather than relying on an installed version of Visual Studio),
-REM but fallback to detection path if not provided.
-if not defined msBuildPath (
-  if not exist "%InstallDir%\MSBuild\15.0\Bin\MSBuild.exe" (
-    echo ERROR: MsBuild couldn't be found
-    exit /b 1
-  )
-  else (
-    SET "msBuildPath=%InstallDir%\MSBuild\15.0\Bin\MSBuild.exe"
-  )
-)
-
+REM TODO: Is this necessary?
 call "%InstallDir%\Common7\Tools\VsDevCmd.bat"
 
-set VcpkgIntegration=%VcpkgInstallRoot%scripts\buildsystems\msbuild\vcpkg.targets
+.scripts\restore.cmd
 
-vcpkg install cpprestsdk:x64-windows
-vcpkg install flatbuffers:x64-windows
-
-SET PATH=%PATH%;%VcpkgInstallRoot%installed\x64-windows\tools\flatbuffers
-
-REM Need to install nuget packages before Visual Studio starts to make ANTLR targets available.
-nuget install -o packages ext_libs\vowpal_wabbit\vowpalwabbit\packages.config
-nuget install -o packages bindings\cs\rl.net.native\packages.config
-nuget install -o packages rlclientlib\packages.config
-nuget install -o packages unit_tests\packages.config
-
-dotnet restore rl.sln
-
-"%InstallDir%\MSBuild\15.0\Bin\MSBuild.exe" "rl.sln" /m /verbosity:normal /p:Configuration=Release;Platform=x64
+.scripts\build.cmd

--- a/rlclientlib/rlclientlib.vcxproj
+++ b/rlclientlib/rlclientlib.vcxproj
@@ -86,7 +86,7 @@
       <SubSystem>Windows</SubSystem>
     </Link>
     <PreBuildEvent>
-      <Command>flatc.exe -o $(SolutionDir)rlclientlib\generated\ --cpp $(SolutionDir)rlclientlib\schema\OutcomeEvent.fbs $(SolutionDir)rlclientlib\schema\RankingEvent.fbs</Command>
+      <Command>$(flatcPath) -o $(SolutionDir)rlclientlib\generated\ --cpp $(SolutionDir)rlclientlib\schema\OutcomeEvent.fbs $(SolutionDir)rlclientlib\schema\RankingEvent.fbs</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Generate FlatBuffer</Message>
@@ -105,7 +105,7 @@
       <SubSystem>Windows</SubSystem>
     </Link>
     <PreBuildEvent>
-      <Command>flatc.exe -o $(SolutionDir)rlclientlib\generated\ --cpp $(SolutionDir)rlclientlib\schema\OutcomeEvent.fbs $(SolutionDir)rlclientlib\schema\RankingEvent.fbs</Command>
+      <Command>$(flatcPath) -o $(SolutionDir)rlclientlib\generated\ --cpp $(SolutionDir)rlclientlib\schema\OutcomeEvent.fbs $(SolutionDir)rlclientlib\schema\RankingEvent.fbs</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Generate FlatBuffer</Message>
@@ -128,7 +128,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
     <PreBuildEvent>
-      <Command>flatc.exe -o $(SolutionDir)rlclientlib\generated\ --cpp $(SolutionDir)rlclientlib\schema\OutcomeEvent.fbs $(SolutionDir)rlclientlib\schema\RankingEvent.fbs</Command>
+      <Command>$(flatcPath) -o $(SolutionDir)rlclientlib\generated\ --cpp $(SolutionDir)rlclientlib\schema\OutcomeEvent.fbs $(SolutionDir)rlclientlib\schema\RankingEvent.fbs</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Generate FlatBuffer</Message>
@@ -151,7 +151,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
     <PreBuildEvent>
-      <Command>flatc.exe -o $(SolutionDir)rlclientlib\generated\ --cpp $(SolutionDir)rlclientlib\schema\OutcomeEvent.fbs $(SolutionDir)rlclientlib\schema\RankingEvent.fbs</Command>
+      <Command>$(flatcPath) -o $(SolutionDir)rlclientlib\generated\ --cpp $(SolutionDir)rlclientlib\schema\OutcomeEvent.fbs $(SolutionDir)rlclientlib\schema\RankingEvent.fbs</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Generate FlatBuffer</Message>


### PR DESCRIPTION
Our build script is very monolithic and difficult to run only some parts of locally or in customized larger builds - which makes it difficult to keep the build steps in sync when using in different dependent repos. 

Breaking it out into "target"-like steps should make this much easier.