### PR TITLE
Fix issue with compiler not liking /ZI and /guard:cf

### DIFF
--- a/bindings/cs/rl.net.native/rl.net.native.vcxproj
+++ b/bindings/cs/rl.net.native/rl.net.native.vcxproj
@@ -58,6 +58,7 @@
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ControlFlowGuard>Guard</ControlFlowGuard>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
Something changed in newer versions of VS to enable Edit+Continue by default for x64 native code. Unfortunately, this does not play well with /guard:cf.

The fix is to set a value for PDB generation to disable Edit+Continue.