### PR TITLE
fix flatcPath for Visual Studio build

### DIFF
--- a/rlclientlib/rlclientlib.vcxproj
+++ b/rlclientlib/rlclientlib.vcxproj
@@ -24,6 +24,7 @@
     <RootNamespace>rlclientlib</RootNamespace>
     <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
     <ProjectName>rlclientlib</ProjectName>
+    <flatcPath Condition="'$(flatcPath)'==''">flatc.exe</flatcPath>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
flatcPath not set for building with Visual Studio