### PR TITLE
model data update fix

### DIFF
--- a/include/model_mgmt.h
+++ b/include/model_mgmt.h
@@ -4,6 +4,7 @@
 
 #include <utility>
 #include <vector>
+#include <string>
 
 // Declare const pointer for internal linkage
 namespace reinforcement_learning {

--- a/include/model_mgmt.h
+++ b/include/model_mgmt.h
@@ -64,7 +64,7 @@ namespace reinforcement_learning { namespace model_management {
     class i_model {
     public:
       virtual int update(const model_data& data, bool& model_ready, api_status* status = nullptr) = 0;
-      virtual int choose_rank(uint64_t rnd_seed, const char* features, std::vector<int>& action_ids, std::vector<float>& action_pdf, const char*& model_version, api_status* status = nullptr) = 0;
+      virtual int choose_rank(uint64_t rnd_seed, const char* features, std::vector<int>& action_ids, std::vector<float>& action_pdf, std::string& model_version, api_status* status = nullptr) = 0;
       virtual ~i_model() = default;
     };
 }}

--- a/include/ranking_response.h
+++ b/include/ranking_response.h
@@ -103,6 +103,15 @@ namespace reinforcement_learning {
      * @param model_id
      */
     void set_model_id(const char* model_id);
+ 
+    /**
+     * @brief Set the model_id.
+     * Every call to choose action is associated with a unique model used to predict.  A unique model_id
+     * is associated with each unique model. (This is set internally by the API).
+     * Input model_id is left in an unspecified but valid state.
+     * @param model_id
+     */
+    void set_model_id(std::string&& model_id);
 
     /**
      * @brief Get the model_id.

--- a/rlclientlib/live_model_impl.cc
+++ b/rlclientlib/live_model_impl.cc
@@ -287,11 +287,11 @@ namespace reinforcement_learning {
 
     std::vector<int> action_ids;
     std::vector<float> action_pdf;
-    const char* model_version;
+    std::string model_version;
 
     RETURN_IF_FAIL(_model->choose_rank(seed, context, action_ids, action_pdf, model_version, status));
 
-    return sample_and_populate_response(seed, action_ids, action_pdf, model_version, response, _trace_logger.get(), status);
+    return sample_and_populate_response(seed, action_ids, action_pdf, std::move(model_version), response, _trace_logger.get(), status);
   }
 
   int live_model_impl::init_model_mgmt(api_status* status) {

--- a/rlclientlib/live_model_impl.cc
+++ b/rlclientlib/live_model_impl.cc
@@ -208,8 +208,14 @@ namespace reinforcement_learning {
   }
 
   void live_model_impl::handle_model_update(const model_management::model_data& data) {
-	api_status status;
-	bool model_ready = false;
+    if (data.refresh_count() == 0) {
+      TRACE_INFO(_trace_logger, "Model was not updated since previous download");
+      return;
+    }
+
+    api_status status;
+
+    bool model_ready = false;
 
     if (_model->update(data, model_ready, &status) != error_code::success) {
       _error_cb.report_error(status);

--- a/rlclientlib/ranking_response.cc
+++ b/rlclientlib/ranking_response.cc
@@ -44,6 +44,10 @@ namespace reinforcement_learning {
     _model_id = model_id;
   }
 
+  void ranking_response::set_model_id(std::string&& model_id) {
+    _model_id.assign(std::move(model_id));
+  }
+
   const char* ranking_response::get_model_id() const {
     return _model_id.c_str();
   }

--- a/rlclientlib/sampling.cc
+++ b/rlclientlib/sampling.cc
@@ -7,7 +7,7 @@
 
 namespace e = exploration;
 namespace reinforcement_learning {
-int sample_and_populate_response(uint64_t rnd_seed, std::vector<int>& action_ids, std::vector<float>& pdf, const char* model_id, ranking_response& response, i_trace* trace_logger, api_status* status) {
+int sample_and_populate_response(uint64_t rnd_seed, std::vector<int>& action_ids, std::vector<float>& pdf, std::string&& model_id, ranking_response& response, i_trace* trace_logger, api_status* status) {
     try {
       // Pick a slot using the pdf. NOTE: sample_after_normalizing() can change the pdf
       uint32_t chosen_index;
@@ -30,7 +30,7 @@ int sample_and_populate_response(uint64_t rnd_seed, std::vector<int>& action_ids
       }
 
       response.set_chosen_action_id(action_ids[chosen_index]);
-      response.set_model_id(model_id);
+      response.set_model_id(std::move(model_id));
       return error_code::success;
     }
     catch ( const std::exception& e) {

--- a/rlclientlib/sampling.h
+++ b/rlclientlib/sampling.h
@@ -7,5 +7,5 @@ namespace reinforcement_learning {
 }
 
 namespace reinforcement_learning {
-    int sample_and_populate_response(uint64_t rnd_seed, std::vector<int>& action_ids, std::vector<float>& pdf, const char* model_id, ranking_response& response, i_trace* trace_logger, api_status* status);
+    int sample_and_populate_response(uint64_t rnd_seed, std::vector<int>& action_ids, std::vector<float>& pdf, std::string&& model_id, ranking_response& response, i_trace* trace_logger, api_status* status);
 }

--- a/rlclientlib/vw_model/pdf_model.cc
+++ b/rlclientlib/vw_model/pdf_model.cc
@@ -23,7 +23,7 @@ namespace reinforcement_learning { namespace model_management {
     const char* features, 
     std::vector<int>& action_ids, 
     std::vector<float>& action_pdf, 
-    const char*& model_version,
+    std::string& model_version,
     api_status* status) {
     try 
     {

--- a/rlclientlib/vw_model/pdf_model.h
+++ b/rlclientlib/vw_model/pdf_model.h
@@ -12,7 +12,7 @@ namespace reinforcement_learning { namespace model_management {
   public:
     pdf_model(i_trace* trace_logger);
     int update(const model_data& data, bool& model_ready, api_status* status = nullptr) override;
-    int choose_rank(uint64_t rnd_seed, const char* features, std::vector<int>& action_ids, std::vector<float>& action_pdf, const char*& model_version, api_status* status = nullptr) override;
+    int choose_rank(uint64_t rnd_seed, const char* features, std::vector<int>& action_ids, std::vector<float>& action_pdf, std::string& model_version, api_status* status = nullptr) override;
   private:
     std::unique_ptr<safe_vw> _vw;
     i_trace* _trace_logger;

--- a/rlclientlib/vw_model/vw_model.cc
+++ b/rlclientlib/vw_model/vw_model.cc
@@ -13,6 +13,12 @@ namespace reinforcement_learning { namespace model_management {
 
   int vw_model::update(const model_data& data, bool& model_ready, api_status* status) {
     try {
+      if (data.refresh_count() == 0) {
+        TRACE_INFO(_trace_logger, "Model was not updated since previous download");
+        model_ready = true;
+        return error_code::success;
+      }
+
       TRACE_INFO(_trace_logger, utility::concat("Received new model data. With size ", data.data_sz()));
 	  
       if (data.data_sz() > 0)

--- a/rlclientlib/vw_model/vw_model.cc
+++ b/rlclientlib/vw_model/vw_model.cc
@@ -13,12 +13,6 @@ namespace reinforcement_learning { namespace model_management {
 
   int vw_model::update(const model_data& data, bool& model_ready, api_status* status) {
     try {
-      if (data.refresh_count() == 0) {
-        TRACE_INFO(_trace_logger, "Model was not updated since previous download");
-        model_ready = true;
-        return error_code::success;
-      }
-
       TRACE_INFO(_trace_logger, utility::concat("Received new model data. With size ", data.data_sz()));
 	  
       if (data.data_sz() > 0)

--- a/rlclientlib/vw_model/vw_model.cc
+++ b/rlclientlib/vw_model/vw_model.cc
@@ -37,7 +37,7 @@ namespace reinforcement_learning { namespace model_management {
     const char* features, 
     std::vector<int>& action_ids, 
     std::vector<float>& action_pdf, 
-    const char*& model_version,
+    std::string& model_version,
     api_status* status) {
     try {
       pooled_vw vw(_vw_pool, _vw_pool.get_or_create());

--- a/rlclientlib/vw_model/vw_model.h
+++ b/rlclientlib/vw_model/vw_model.h
@@ -12,7 +12,7 @@ namespace reinforcement_learning { namespace model_management {
   public:
     vw_model(i_trace* trace_logger);
     int update(const model_data& data, bool& model_ready, api_status* status = nullptr) override;
-    int choose_rank(uint64_t rnd_seed, const char* features, std::vector<int>& action_ids, std::vector<float>& action_pdf, const char*& model_version, api_status* status = nullptr) override;
+    int choose_rank(uint64_t rnd_seed, const char* features, std::vector<int>& action_ids, std::vector<float>& action_pdf, std::string& model_version, api_status* status = nullptr) override;
   private:
     using vw_ptr = std::shared_ptr<safe_vw>;
     using pooled_vw = utility::pooled_object_guard<safe_vw, safe_vw_factory>;

--- a/unit_test/live_model_test.cc
+++ b/unit_test/live_model_test.cc
@@ -126,14 +126,16 @@ BOOST_AUTO_TEST_CASE(live_model_ranking_request_pdf_passthrough) {
   config.set(r::name::EH_TEST, "true");
   config.set(r::name::MODEL_SRC, r::value::NO_MODEL_DATA);
   config.set(r::name::MODEL_IMPLEMENTATION, r::value::PASSTHROUGH_PDF_MODEL);
+  config.set(r::name::MODEL_BACKGROUND_REFRESH, "false");
 
   r::api_status status;
 
   //create the ds live_model, and initialize it with the config
   
   r::live_model model = create_mock_live_model(config, &r::data_transport_factory, &r::model_factory, nullptr);
-  BOOST_CHECK_EQUAL(model.init(&status), err::success);
 
+  BOOST_CHECK_EQUAL(model.init(&status), err::success);
+  BOOST_CHECK_EQUAL(model.refresh_model(&status), err::success);
   const auto event_id = "event_id";
 
   r::ranking_response response;

--- a/unit_test/mock_util.cc
+++ b/unit_test/mock_util.cc
@@ -63,10 +63,9 @@ std::unique_ptr<fakeit::Mock<m::i_data_transport>> get_mock_failing_data_transpo
 std::unique_ptr<fakeit::Mock<m::i_model>> get_mock_model() {
   auto mock = std::unique_ptr<Mock<m::i_model>>(
     new fakeit::Mock<m::i_model>());
-  const std::function<int(uint64_t, const char*, std::vector<int>&, std::vector<float>&, const char*&, r::api_status*)> choose_rank_fn =
-    [](uint64_t, const char*, std::vector<int>&, std::vector<float>&, const char*& model_version, r::api_status*) {
-    static const std::string model_id = "model_id";
-    model_version = model_id.c_str();
+  const std::function<int(uint64_t, const char*, std::vector<int>&, std::vector<float>&, std::string&, r::api_status*)> choose_rank_fn =
+    [](uint64_t, const char*, std::vector<int>&, std::vector<float>&, std::string& model_version, r::api_status*) {
+    model_version = "model_id";
     return r::error_code::success;
   };
   When(Method((*mock), update)).AlwaysReturn(r::error_code::success);


### PR DESCRIPTION
vw_model was switching back to exploration if there is no model data changes on server side since last update (i.e. if model export frequency is more than model downloader frequency).