### PR TITLE
Add binding_tracer.cc to CMakeLists.txt

### DIFF
--- a/bindings/cs/rl.net.native/CMakeLists.txt
+++ b/bindings/cs/rl.net.native/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(rl.net.native SHARED
   rl.net.config.cc
   rl.net.live_model.cc
   rl.net.ranking_response.cc
+  binding_tracer.cc
 )
 
 if(MSVC)


### PR DESCRIPTION
binding_tracer symbol is not built in Linux as only header file is being included.