### PR TITLE
Adding the submodule update command to the readme to ensure everything is in sync.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ Cpprest needs to be installed:
 ```
 cd ~
 git clone https://github.com/Microsoft/cpprestsdk.git cpprestsdk
-cd cpprestsdk/Release
+cd cpprestsdk
 # Checkout 2.10.1 version of cpprestsdk
 git checkout e8dda215426172cd348e4d6d455141f40768bf47
+git submodule update --init
+cd Release
 mkdir build
 cd build
 cmake ..


### PR DESCRIPTION
Currently the readme doesn't include a command to update the submodules in the cpprestsdk project after the checkout command. This should be in ran to make sure all of the submodules are in sync.