### PR TITLE
Fix regression in Sending JSON reward

### DIFF
--- a/.scripts/find-vs2017.cmd
+++ b/.scripts/find-vs2017.cmd
@@ -1,0 +1,6 @@
+IF NOT DEFINED VsInstallDir (
+    REM Try to find VS Install
+    FOR /f "usebackq tokens=*" %%i IN (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.Component.MSBuild -property installationPath`) DO (
+        SET "VsInstallDir=%%i"
+    )
+)

--- a/.scripts/init.cmd
+++ b/.scripts/init.cmd
@@ -4,16 +4,28 @@ IF NOT DEFINED nugetPath (
 )
 
 IF NOT DEFINED msbuildPath (
-    REM Try to find VS Install
-    for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.Component.MSBuild -property installationPath`) do (
-        set InstallDir=%%i
-    )
+    CALL %~dp0find-vs2017.cmd
+)
 
-    if not exist "%InstallDir%\MSBuild\15.0\Bin\MSBuild.exe" (
-        echo ERROR: MsBuild couldn't be found
-        exit /b 1
-    ) else (
-        SET "msBuildPath=%InstallDir%\MSBuild\15.0\Bin\MSBuild.exe"
+IF NOT DEFINED vstestPath (
+    CALL %~dp0find-vs2017.cmd
+)
+
+IF NOT DEFINED msbuildPath (
+    IF NOT EXIST "%VsInstallDir%\MSBuild\15.0\Bin\MSBuild.exe" (
+        ECHO ERROR: MsBuild couldn't be found
+        EXIT /b 1
+    ) ELSE (
+        SET "msBuildPath=%VsInstallDir%\MSBuild\15.0\Bin\MSBuild.exe"
+    )
+)
+
+IF NOT DEFINED vstestPath (
+    IF NOT EXIST "%VsInstallDir%\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe" (
+        ECHO ERROR: vstest.console couldn't be found
+        EXIT /b 1
+    ) ELSE (
+        SET "vstestPath=%VsInstallDir%\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
     )
 )
 

--- a/.scripts/test.cmd
+++ b/.scripts/test.cmd
@@ -15,7 +15,7 @@ ECHO Running RL Unit Tests
 "%rlRoot%\x64\Release\unit_test.exe"
 
 ECHO Running RL.Net Unit Tests
-REM %vstestPath% /Platform:x64 /inIsolation "%vwRoot%\vowpalwabbit\x64\Release\cs_unittest.dll" /TestCaseFilter:"TestCategory!=NotOnVSO"
+%vstestPath% /Platform:x64 /inIsolation "%rlRoot%\x64\Release\Rl.Net.Cli.Test.dll" /TestCaseFilter:"TestCategory!=NotOnVSO"
 
 POPD
 

--- a/.scripts/test.cmd
+++ b/.scripts/test.cmd
@@ -15,7 +15,7 @@ ECHO Running RL Unit Tests
 "%rlRoot%\x64\Release\unit_test.exe"
 
 ECHO Running RL.Net Unit Tests
-%vstestPath% /Platform:x64 /inIsolation "%rlRoot%\x64\Release\Rl.Net.Cli.Test.dll" /TestCaseFilter:"TestCategory!=NotOnVSO"
+"%vstestPath%" /Platform:x64 /InIsolation "%rlRoot%\x64\Release\Rl.Net.Cli.Test.dll" /TestCaseFilter:"TestCategory!=NotOnVSO"
 
 POPD
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,8 @@ environment:
   VcpkgInstallRoot: c:\tools\vcpkg\
   rlRoot: C:\reinforcement_learning
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
+  msbuildPath: msbuild
+  vstestPath: vstest.console
 install:
   - git submodule update --init --recursive
 build_script:

--- a/bindings/cs/rl.net.cli.test/UnicodeTest.cs
+++ b/bindings/cs/rl.net.cli.test/UnicodeTest.cs
@@ -417,6 +417,8 @@ namespace Rl.Net.Cli.Test
 
                     return NativeMethods.SuccessStatus;
                 };
+
+            liveModel.QueueOutcomeEvent(eventId, outcomeJson);
         }
 
         [TestMethod]

--- a/bindings/cs/rl.net/LiveModel.cs
+++ b/bindings/cs/rl.net/LiveModel.cs
@@ -216,7 +216,7 @@ namespace Rl.Net
             CheckJsonString(outcomeJson);
 
             fixed (byte* eventIdUtf8Bytes = NativeMethods.StringEncoding.GetBytes(eventId))
-            fixed (byte* outcomeJsonUtf8Bytes = NativeMethods.StringEncoding.GetBytes(eventId))
+            fixed (byte* outcomeJsonUtf8Bytes = NativeMethods.StringEncoding.GetBytes(outcomeJson))
             {
                 return NativeMethods.LiveModelReportOutcomeJson(liveModel, new IntPtr(eventIdUtf8Bytes), new IntPtr(outcomeJsonUtf8Bytes), apiStatus);
             }


### PR DESCRIPTION
I broke the JSON reward path in the UTF fix due to a copy-and-paste error, and on top of that the test that should have caught it did not actually have any call into the test code, it just set up the test with running it.

On top of that, test.cmd was never updated to run the .NET unit tests.

This is all fixed by this change.