### PR TITLE
Flatbuffer allocator undefined behavior fix

### DIFF
--- a/rlclientlib/logger/flatbuffer_allocator.cc
+++ b/rlclientlib/logger/flatbuffer_allocator.cc
@@ -16,7 +16,11 @@ namespace reinforcement_learning {
                                                      size_t in_use_back, size_t in_use_front) {
     assert(new_size > old_size); // vector_downward only grows
     _buffer.resize_body_region(new_size);
-    memcpy_downward(_buffer.body_begin(), old_size, _buffer.body_begin(), new_size, in_use_back, in_use_front);
+    //implementation is almost identical with memcpy_downward from https://github.com/google/flatbuffers/blob/master/include/flatbuffers/flatbuffers.h,
+    //but since we are staying at the same chunk, we
+    //1) cannot use memcpy which has undefined behavior on copying data between overlapping regions (https://en.cppreference.com/w/cpp/string/byte/memcpy)
+    //2) do not need to copy head
+    memmove(_buffer.body_begin() + new_size - in_use_back, _buffer.body_begin() + old_size - in_use_back, in_use_back);
     return _buffer.body_begin();
   }
 }

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(rltest
   eventhub_client_test.cc
   explore_test.cc
   factory_test.cc
+  fb_serializer_test.cc
   json_context_parse_test.cc
   live_model_test.cc
   main.cc

--- a/unit_test/fb_serializer_test.cc
+++ b/unit_test/fb_serializer_test.cc
@@ -66,24 +66,29 @@ BOOST_AUTO_TEST_CASE(fb_serializer_ranking_event) {
   std::string event_id("an_event_id");
   std::string context("some_context");
   const timestamp ts;
-  auto re = ranking_event::choose_rank(event_id.c_str(),context.c_str(),0,resp,ts,0.33f);
-  serializer.add(re);
+  const size_t events_count = 10;
+  for (size_t i = 0; i < events_count; ++i) {
+    auto re = ranking_event::choose_rank(event_id.c_str(),context.c_str(),0,resp,ts,0.33f);
+    serializer.add(re);
+  }
   serializer.finalize();
 
   flatbuffers::Verifier v(db.body_begin(), db.body_filled_size());
   const RankingEventBatch* ranking_event_batch = GetRankingEventBatch(db.body_begin());
   BOOST_CHECK(ranking_event_batch->Verify(v));
   const auto& events = *(ranking_event_batch->events());
-  BOOST_CHECK_EQUAL(events.size(), 1);
-  const auto& event = *events[0];
-  BOOST_CHECK_EQUAL(event.action_ids()->size(), 3);
-  std::vector<int> expected_ids{3,1,2};
-  BOOST_CHECK_EQUAL_COLLECTIONS(event.action_ids()->begin(), event.action_ids()->end(), expected_ids.begin(), expected_ids.end());
-  BOOST_CHECK_EQUAL_COLLECTIONS(event.context()->begin(), event.context()->end(), context.begin(), context.end());
-  BOOST_CHECK_EQUAL(event.model_id()->str(), model_id);
-  BOOST_CHECK_EQUAL(event.event_id()->str(), event_id);
-  std::vector<float> expected_prob{.8f + .2f / 3, .2f / 3, .2f / 3};
-  BOOST_CHECK_EQUAL_COLLECTIONS(event.probabilities()->begin(), event.probabilities()->end(), expected_prob.begin(), expected_prob.end());
-  BOOST_CHECK_EQUAL(event.deferred_action(), false);
-  BOOST_CHECK_EQUAL(event.pass_probability(), 0.33f);
+  BOOST_CHECK_EQUAL(events.size(), events_count);
+  for (size_t i = 0; i < events_count; ++i) {
+    const auto& event = *events[i];
+    BOOST_CHECK_EQUAL(event.action_ids()->size(), 3);
+    std::vector<int> expected_ids{3,1,2};
+    BOOST_CHECK_EQUAL_COLLECTIONS(event.action_ids()->begin(), event.action_ids()->end(), expected_ids.begin(), expected_ids.end());
+    BOOST_CHECK_EQUAL_COLLECTIONS(event.context()->begin(), event.context()->end(), context.begin(), context.end());
+    BOOST_CHECK_EQUAL(event.model_id()->str(), model_id);
+    BOOST_CHECK_EQUAL(event.event_id()->str(), event_id);
+    std::vector<float> expected_prob{.8f + .2f / 3, .2f / 3, .2f / 3};
+    BOOST_CHECK_EQUAL_COLLECTIONS(event.probabilities()->begin(), event.probabilities()->end(), expected_prob.begin(), expected_prob.end());
+    BOOST_CHECK_EQUAL(event.deferred_action(), false);
+    BOOST_CHECK_EQUAL(event.pass_probability(), 0.33f);
+  }
 }


### PR DESCRIPTION
Getting rid of memcpy between overlapping regions.