### PR TITLE
Add data limit paramater and parallelism options

### DIFF
--- a/bindings/cs/rl.net.cli/PerfTestCommand.cs
+++ b/bindings/cs/rl.net.cli/PerfTestCommand.cs
@@ -47,17 +47,19 @@ namespace Rl.Net.Cli
             Statistics stats = new Statistics();
             object lockObj = new object();
             Parallel.ForEach(processortags, item => 
+            {
+                PerfTestStepProvider step = DoWork(item);
+                lock (lockObj)
                 {
-                    PerfTestStepProvider step = DoWork(item);
-                    lock (lockObj)
-                    {
-                        stats += step.Stats;
-                    }
+                    stats += step.Stats;
                 }
-            );
+            });
 
-            Console.WriteLine("Overall stats");
-            stats.Print();
+            if (this.Parallelism > 1)
+            {
+                Console.WriteLine("Overall stats");
+                stats.Print();
+            }
         }
 
         private PerfTestStepProvider DoWork(string tag)

--- a/bindings/cs/rl.net.cli/RLDriver.cs
+++ b/bindings/cs/rl.net.cli/RLDriver.cs
@@ -78,7 +78,7 @@ namespace Rl.Net.Cli
                 // TODO: Change this to be a command-line arg
                 Thread.Sleep(StepInterval);
 
-                if (++stepsCount % 1000 == 0)
+                if (++stepsCount % 10000 == 0)
                 {
                     Console.Out.WriteLine($"Processed {stepsCount} steps.");
                 }

--- a/bindings/cs/rl.net.cli/Statistics.cs
+++ b/bindings/cs/rl.net.cli/Statistics.cs
@@ -37,7 +37,7 @@ namespace Rl.Net.Cli
             Console.WriteLine($"Time taken: {(this.ElapsedMs / 1000)} secs");
             Console.WriteLine($"Throughput: {this.Bytes / ((1024 * 1024) * this.ElapsedMs / 1000)} MB / s");
             Console.WriteLine($"Messages sent: {this.Messages}");
-            Console.WriteLine($"Avg Message size: {this.Bytes / (1024 * this.Messages)}");
+            Console.WriteLine($"Avg Message size: {this.Bytes / (1024 * this.Messages)} KB");
             Console.WriteLine($"Msg/s: {this.Messages / (this.ElapsedMs / 1000)}");
         }
     }

--- a/bindings/cs/rl.net.cli/Statistics.cs
+++ b/bindings/cs/rl.net.cli/Statistics.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Rl.Net.Cli
+{
+    public class Statistics
+    {
+        public int Messages { get; private set; }
+
+        public double Bytes { get; private set; }
+
+        public Stopwatch Timer { get; } = Stopwatch.StartNew();
+
+        public long ElapsedMs { get; private set; }
+
+        public static Statistics operator + (Statistics s1, Statistics s2)
+        {
+            return new Statistics()
+            {
+                Bytes = s1.Bytes + s2.Bytes,
+                Messages = s1.Messages + s2.Messages,
+                ElapsedMs = Math.Max(s1.ElapsedMs, s2.ElapsedMs)
+            };
+        }
+
+        public void Update(double byteCount)
+        {
+            Bytes += byteCount;
+            Messages++;
+            ElapsedMs = Timer.ElapsedMilliseconds;
+        }
+
+        public void Print()
+        {
+            Console.WriteLine($"Data sent: {this.Bytes / (1024 * 1024)} MB");
+            Console.WriteLine($"Time taken: {(this.ElapsedMs / 1000)} secs");
+            Console.WriteLine($"Throughput: {this.Bytes / ((1024 * 1024) * this.ElapsedMs / 1000)} MB / s");
+            Console.WriteLine($"Messages sent: {this.Messages}");
+            Console.WriteLine($"Avg Message size: {this.Bytes / (1024 * this.Messages)}");
+            Console.WriteLine($"Msg/s: {this.Messages / (this.ElapsedMs / 1000)}");
+        }
+    }
+}


### PR DESCRIPTION
Add data limit paramater and parallelism options
--data 10 will push 10GB data
-p 2 will psuh data using 2 parallel tasks
-p 0 will use Environment.ProcessorCount number of tasks to push data. 100+MB/s throughput even though event hub can't handle this speed