### PR TITLE
Fix PDF Passthrough unit test timing issue

### DIFF
--- a/unit_test/live_model_test.cc
+++ b/unit_test/live_model_test.cc
@@ -127,6 +127,10 @@ BOOST_AUTO_TEST_CASE(live_model_ranking_request_pdf_passthrough) {
   config.set(r::name::MODEL_SRC, r::value::NO_MODEL_DATA);
   config.set(r::name::MODEL_IMPLEMENTATION, r::value::PASSTHROUGH_PDF_MODEL);
 
+  // Background refresh introduces a timing issue where the model might not have updated properly
+  // before the choose_rank() call.
+  config.set(r::name::MODEL_BACKGROUND_REFRESH, "false"); 
+
   r::api_status status;
 
   //create the ds live_model, and initialize it with the config


### PR DESCRIPTION
Our default configuration for model refresh is "background refresh enabled". This means that there is a thread polling for model updates every X amount of wall clock time. In UnitTests, this introduces dynamic behaviour, leading to flaky tests.

Setting model_background_refresh to false, makes the test behave consistently.