### PR TITLE
Cleanup cmake files for devirtualization by using a pragma in header

### DIFF
--- a/.scripts/linux/build.sh
+++ b/.scripts/linux/build.sh
@@ -10,6 +10,6 @@ cd $REPO_DIR
 # Build reinforcement_learning
 mkdir -p build
 cd build
-cmake .. -DTURN_OFF_DEVIRTUALIZE=On
+cmake ..
 NUM_PROCESSORS=$(cat nprocs.txt)
 make all -j${NUM_PROCESSORS}

--- a/.scripts/macos/build.sh
+++ b/.scripts/macos/build.sh
@@ -12,6 +12,6 @@ cd build
 # On MacOS CMake is unable to find brew installed OpenSSL, so we need to pass it where to look.
 OPEN_SSL_DIR="/usr/local/Cellar/openssl/1.0.2s"
 
-cmake .. -DTURN_OFF_DEVIRTUALIZE=On -DOPENSSL_ROOT_DIR=$OPEN_SSL_DIR -DOPENSSL_LIBRARIES=$OPEN_SSL_DIR/lib
+cmake .. -DOPENSSL_ROOT_DIR=$OPEN_SSL_DIR -DOPENSSL_LIBRARIES=$OPEN_SSL_DIR/lib
 NUM_PROCESSORS=$(cat nprocs.txt)
 make all -j${NUM_PROCESSORS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,11 +18,6 @@ endif()
 set(CMAKE_CONFIGURATION_TYPES Debug Release CACHE TYPE INTERNAL FORCE)
 set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build, options are: Debug, Release" FORCE)
 
-# Devirtualization is an optimization that changes the vtable if the compiler decides a function
-# doesn't need to be virtual. This is incompatible with the mocking framework used in testing as it
-# makes the vtable structure unpredictable
-option(TURN_OFF_DEVIRTUALIZE "Turn off devirtualize which is required for mocking framework" OFF)
-
 include(ProcessorCount)
 ProcessorCount(NumProcessors)
 message("Number of processors: ${NumProcessors}")

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ cmake .. -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/cmake
 ```
 mkdir build
 cd build
-cmake .. -DTURN_OFF_DEVIRTUALIZE=On
+cmake ..
 make rltest
 make test
 ```

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -31,7 +31,7 @@ cd /reinforcement_learning
 # Build reinforcement_learning
 mkdir -p build
 cd build
-cmake .. -DTURN_OFF_DEVIRTUALIZE=On 
+cmake ..
 NUM_PROCESSORS=$(cat nprocs.txt)
 make -j${NUM_PROCESSORS}
 

--- a/rlclientlib/CMakeLists.txt
+++ b/rlclientlib/CMakeLists.txt
@@ -125,11 +125,6 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   target_link_libraries(rlclientlib PUBLIC Boost::thread)
 endif()
 
-
-if(TURN_OFF_DEVIRTUALIZE)
-  target_compile_options(rlclientlib PUBLIC -fno-devirtualize)
-endif()
-
 install(TARGETS rlclientlib
   INCLUDES DESTINATION rlclientlib
   ARCHIVE DESTINATION lib

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -27,15 +27,6 @@ add_executable(rltest
   watchdog_test.cc
 )
 
-# Devirtualization is an optimization that changes the vtable if the compiler decides a function
-# doesn't need to be virtual. This is incompatible with the mocking framework used in testing as it
-# makes the vtable structure unpredictable
-if(MSVC)
-  # MSVC doesn't optimize aggresively enough for this bug to be an issue right now.
-else()
-  target_compile_options(rltest PRIVATE -fno-devirtualize)
-endif()
-
 # Add the include directories from rlclientlib target for testing
 target_include_directories(rltest PRIVATE $<TARGET_PROPERTY:rlclientlib,INCLUDE_DIRECTORIES>)
 

--- a/unit_test/live_model_test.cc
+++ b/unit_test/live_model_test.cc
@@ -19,6 +19,14 @@
 
 #include "mock_util.h"
 
+#ifdef __GNUG__
+
+// Fakeit does not work with GCC's devirtualization
+// which is enabled with -O2 (the default) or higher.
+#pragma GCC optimize("no-devirtualize")
+
+#endif
+
 #include <fakeit/fakeit.hpp>
 
 namespace r = reinforcement_learning;
@@ -44,7 +52,7 @@ namespace {
 
   const auto JSON_CONTEXT = R"({"_multi":[{},{}]})";
   const auto JSON_CONTEXT_PDF = R"({"Shared":{"t":"abc"}, "_multi":[{"Action":{"c":1}},{"Action":{"c":2}}],"p":[0.4, 0.6]})";
-  const float EXPECTED_PDF[2] = { 0.4f, 0.6f }; 
+  const float EXPECTED_PDF[2] = { 0.4f, 0.6f };
 
   r::live_model create_mock_live_model(
     const u::configuration& config,
@@ -129,12 +137,12 @@ BOOST_AUTO_TEST_CASE(live_model_ranking_request_pdf_passthrough) {
 
   // Background refresh introduces a timing issue where the model might not have updated properly
   // before the choose_rank() call.
-  config.set(r::name::MODEL_BACKGROUND_REFRESH, "false"); 
+  config.set(r::name::MODEL_BACKGROUND_REFRESH, "false");
 
   r::api_status status;
 
   //create the ds live_model, and initialize it with the config
-  
+
   r::live_model model = create_mock_live_model(config, &r::data_transport_factory, &r::model_factory, nullptr);
 
   BOOST_CHECK_EQUAL(model.init(&status), err::success);
@@ -144,7 +152,7 @@ BOOST_AUTO_TEST_CASE(live_model_ranking_request_pdf_passthrough) {
 
   // request ranking
   BOOST_CHECK_EQUAL(model.choose_rank(event_id, JSON_CONTEXT_PDF, response), err::success);
-  
+
   size_t num_actions = response.size();
   BOOST_CHECK_EQUAL(num_actions, 2);
 

--- a/unit_test/mock_util.h
+++ b/unit_test/mock_util.h
@@ -3,9 +3,18 @@
 #include "factory_resolver.h"
 #include "sender.h"
 
+#include <memory>
+
+#ifdef __GNUG__
+
+// Fakeit does not work with GCC's devirtualization
+// which is enabled with -O2 (the default) or higher.
+#pragma GCC optimize("no-devirtualize")
+
+#endif
+
 #include <fakeit/fakeit.hpp>
 
-#include <memory>
 using buffer_t = std::shared_ptr <reinforcement_learning::utility::data_buffer>;
 
 std::unique_ptr<fakeit::Mock<reinforcement_learning::i_sender>> get_mock_sender(int send_return_code);

--- a/unit_test/trace_logger_test.cc
+++ b/unit_test/trace_logger_test.cc
@@ -4,7 +4,6 @@
 #endif
 
 #include <boost/test/unit_test.hpp>
-#include <fakeit/fakeit.hpp>
 #include "mock_util.h"
 #include "live_model.h"
 #include "config_utility.h"
@@ -13,6 +12,16 @@
 #include "api_status.h"
 #include "err_constants.h"
 #include "console_tracer.h"
+
+#ifdef __GNUG__
+
+// Fakeit does not work with GCC's devirtualization
+// which is enabled with -O2 (the default) or higher.
+#pragma GCC optimize("no-devirtualize")
+
+#endif
+
+#include <fakeit/fakeit.hpp>
 
 namespace r = reinforcement_learning;
 namespace u = reinforcement_learning::utility;


### PR DESCRIPTION
By using the pragma in the header we do not need to specify anything in the CMake, this simplifies the build scripts a fair bit.