### PR TITLE
Fix SafeHandle memory safety

### DIFF
--- a/bindings/cs/rl.net/ApiStatus.cs
+++ b/bindings/cs/rl.net/ApiStatus.cs
@@ -27,18 +27,29 @@ namespace Rl.Net {
         {
         }
 
-        public int ErrorCode => GetApiStatusErrorCode(this.handle);
+        public int ErrorCode
+        {
+            get
+            {
+                int result = GetApiStatusErrorCode(this.DangerousGetHandle());
+
+                GC.KeepAlive(this);
+                return result;
+            }
+        } 
 
         public string ErrorMessage
         {
             get
             {
-                IntPtr errorMessagePtr = GetApiStatusErrorMessage(this.handle);
+                IntPtr errorMessagePtr = GetApiStatusErrorMessage(this.DangerousGetHandle());
 
                 // We cannot rely on P/Invoke's marshalling here, because it assumes that it can deallocate the string
                 // it receives, after converting it to a managed string. We cannot do this, in this case.
+                string result = NativeMethods.StringMarshallingFunc(errorMessagePtr);
 
-                return NativeMethods.StringMarshallingFunc(errorMessagePtr);
+                GC.KeepAlive(this);
+                return result;
             }
         }
     }

--- a/bindings/cs/rl.net/Configuration.cs
+++ b/bindings/cs/rl.net/Configuration.cs
@@ -141,7 +141,7 @@ namespace Rl.Net {
         {
             config = new Configuration();
 
-            int result = LoadConfigurationFromJson(json, config.NativeHandle, apiStatus.ToNativeHandleOrNullptr());
+            int result = LoadConfigurationFromJson(json, config.DangerousGetHandle(), apiStatus.ToNativeHandleOrNullptrDangerous());
             return result == NativeMethods.SuccessStatus;
         }
 
@@ -162,11 +162,16 @@ namespace Rl.Net {
         {
             get
             {
-                return ConfigurationGet(this.NativeHandle, key, string.Empty);
+                string result = ConfigurationGet(this.DangerousGetHandle(), key, string.Empty);
+
+                GC.KeepAlive(this);
+                return result;
             }
             set
             {
-                ConfigurationSet(this.NativeHandle, key, value ?? string.Empty);
+                ConfigurationSet(this.DangerousGetHandle(), key, value ?? string.Empty);
+
+                GC.KeepAlive(this);
             }
         }
     }

--- a/bindings/cs/rl.net/LiveModelThreadSafe.cs
+++ b/bindings/cs/rl.net/LiveModelThreadSafe.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Rl.Net.Native;
+
+namespace Rl.Net
+{
+    public sealed class LiveModelThreadSafe
+    {
+        private int disposedValue = 0;
+        private LiveModel liveModel;
+        
+        public LiveModelThreadSafe(Configuration config)
+        {
+           this.liveModel = new LiveModel(config);
+        }
+
+        private void InvokeDangerous(Action action)
+        {
+            bool refAdded = false;
+            this.liveModel.DangerousAddRef(ref refAdded);
+
+            try
+            {
+                action();
+            }
+            finally
+            {
+                if (refAdded)
+                {
+                    this.liveModel.DangerousRelease();
+                }
+            }
+        }
+
+        private TResult InvokeDangerous<TResult>(Func<TResult> func)
+        {
+            bool refAdded = false;
+            this.liveModel.DangerousAddRef(ref refAdded);
+            
+            try
+            {
+                return func();
+            }
+            finally
+            {
+                if (refAdded)
+                {
+                    this.liveModel.DangerousRelease();
+                }
+            }
+        }
+
+        public void Init()
+        {
+           InvokeDangerous(this.liveModel.Init);
+        }
+
+        public RankingResponse ChooseRank(string eventId, string contextJson)
+        {
+            return InvokeDangerous(() => this.liveModel.ChooseRank(eventId, contextJson));
+        }
+
+        public RankingResponse ChooseRank(string eventId, string contextJson, ActionFlags flags)
+        {
+            return InvokeDangerous(() => this.liveModel.ChooseRank(eventId, contextJson, flags));
+        }
+
+        public DecisionResponse RequestDecision(string contextJson)
+        {
+            return InvokeDangerous(() => this.liveModel.RequestDecision(contextJson));
+        }
+
+        public DecisionResponse RequestDecision(string contextJson, ActionFlags flags)
+        {
+            return InvokeDangerous(() => this.liveModel.RequestDecision(contextJson, flags));
+        }
+
+        public void QueueActionTakenEvent(string eventId)
+        {
+            InvokeDangerous(() => this.liveModel.QueueActionTakenEvent(eventId));
+        }
+
+        public void QueueOutcomeEvent(string eventId, float outcome)
+        {
+            InvokeDangerous(() => this.liveModel.QueueOutcomeEvent(eventId, outcome));
+        }
+
+        public void QueueOutcomeEvent(string eventId, string outcomeJson)
+        {
+            InvokeDangerous(() => this.liveModel.QueueOutcomeEvent(eventId, outcomeJson));
+        }
+
+        public void RefreshModel()
+        {
+            InvokeDangerous(this.liveModel.RefreshModel);
+        }
+
+        public event EventHandler<ApiStatus> BackgroundError
+        {
+            add
+            {
+                InvokeDangerous(() => this.liveModel.BackgroundError += value);
+            }
+            remove
+            {
+                InvokeDangerous(() => this.liveModel.BackgroundError -= value);
+            }
+        }
+        
+        public event EventHandler<TraceLogEventArgs> TraceLoggerEvent
+        {
+            add
+            {
+                InvokeDangerous(() => this.liveModel.TraceLoggerEvent += value);
+            }
+            remove
+            {
+                InvokeDangerous(() => this.liveModel.TraceLoggerEvent -= value);
+            }
+        }
+    }
+}

--- a/bindings/cs/rl.net/LiveModelThreadSafe.cs
+++ b/bindings/cs/rl.net/LiveModelThreadSafe.cs
@@ -18,10 +18,10 @@ namespace Rl.Net
         private void InvokeDangerous(Action action)
         {
             bool refAdded = false;
-            this.liveModel.DangerousAddRef(ref refAdded);
 
             try
             {
+                this.liveModel.DangerousAddRef(ref refAdded);
                 action();
             }
             finally
@@ -36,10 +36,10 @@ namespace Rl.Net
         private TResult InvokeDangerous<TResult>(Func<TResult> func)
         {
             bool refAdded = false;
-            this.liveModel.DangerousAddRef(ref refAdded);
             
             try
             {
+                this.liveModel.DangerousAddRef(ref refAdded);
                 return func();
             }
             finally

--- a/bindings/cs/rl.net/Native/Global.cs
+++ b/bindings/cs/rl.net/Native/Global.cs
@@ -11,14 +11,14 @@ namespace Rl.Net.Native {
 
         public const int SuccessStatus = 0; // See err_constants.h
 
-        public static IntPtr ToNativeHandleOrNullptr<TObject>(this NativeObject<TObject> nativeObject) where TObject : NativeObject<TObject>
+        public static IntPtr ToNativeHandleOrNullptrDangerous<TObject>(this NativeObject<TObject> nativeObject) where TObject : NativeObject<TObject>
         {
             if (nativeObject == null)
             {
                 return IntPtr.Zero;
             }
 
-            return nativeObject.NativeHandle;
+            return nativeObject.DangerousGetHandle();
         }
     }
 }

--- a/bindings/cs/rl.net/Native/NativeObject.cs
+++ b/bindings/cs/rl.net/Native/NativeObject.cs
@@ -32,14 +32,6 @@ namespace Rl.Net.Native
             this.SetHandle(sharedHandle);
         }
 
-        internal IntPtr NativeHandle
-        {
-            get
-            {
-                return this.handle;
-            }
-        }
-
         override public bool IsInvalid
         {
             get

--- a/bindings/cs/rl.net/RankingResponse.cs
+++ b/bindings/cs/rl.net/RankingResponse.cs
@@ -83,9 +83,12 @@ namespace Rl.Net {
         {
             get
             {
-                IntPtr eventIdUtf8Ptr = NativeMethods.GetRankingEventId(this.NativeHandle);
+                IntPtr eventIdUtf8Ptr = NativeMethods.GetRankingEventId(this.DangerousGetHandle());
 
-                return NativeMethods.StringMarshallingFunc(eventIdUtf8Ptr);
+                string result = NativeMethods.StringMarshallingFunc(eventIdUtf8Ptr);
+
+                GC.KeepAlive(this);
+                return result;
             }
         }
 
@@ -93,9 +96,12 @@ namespace Rl.Net {
         {
             get
             {
-                IntPtr modelIdUtf8Ptr = NativeMethods.GetRankingModelId(this.NativeHandle);
+                IntPtr modelIdUtf8Ptr = NativeMethods.GetRankingModelId(this.DangerousGetHandle());
 
-                return NativeMethods.StringMarshallingFunc(modelIdUtf8Ptr);
+                string result = NativeMethods.StringMarshallingFunc(modelIdUtf8Ptr);
+
+                GC.KeepAlive(this);
+                return result;
             }
         }
 
@@ -103,9 +109,10 @@ namespace Rl.Net {
         {
             get
             {
-                ulong unsignedSize = NativeMethods.GetRankingActionCount(this.NativeHandle).ToUInt64();
+                ulong unsignedSize = NativeMethods.GetRankingActionCount(this.DangerousGetHandle()).ToUInt64();
                 Debug.Assert(unsignedSize < Int64.MaxValue, "We do not support collections with size larger than _I64_MAX/Int64.MaxValue");
     
+                GC.KeepAlive(this);
                 return (long)unsignedSize;
             }
         }
@@ -115,14 +122,15 @@ namespace Rl.Net {
         {
             actionIndex = -1;
             UIntPtr chosenAction;
-            int result = NativeMethods.GetRankingChosenAction(this.NativeHandle, out chosenAction, status.ToNativeHandleOrNullptr());
+            int result = NativeMethods.GetRankingChosenAction(this.DangerousGetHandle(), out chosenAction, status.ToNativeHandleOrNullptrDangerous());
 
-            if (result != NativeMethods.SuccessStatus)
+            bool success = (result == NativeMethods.SuccessStatus);
+            if (success)
             {
-                return false;
+                actionIndex = (long)(chosenAction.ToUInt64());
             }
 
-            actionIndex = (long)(chosenAction.ToUInt64());
+            GC.KeepAlive(this);
             return true;
         }
 
@@ -159,7 +167,13 @@ namespace Rl.Net {
 
             private static New<RankingResponseEnumerator> BindConstructorArguments(RankingResponse rankingResponse)
             {
-                return new New<RankingResponseEnumerator>(() => CreateRankingEnumeratorAdapter(rankingResponse.NativeHandle));
+                return new New<RankingResponseEnumerator>(() => 
+                {
+                    IntPtr result = CreateRankingEnumeratorAdapter(rankingResponse.DangerousGetHandle());
+
+                    GC.KeepAlive(rankingResponse); // TODO: Is this one necessary, or does it live on the heap inside of the delegate?
+                    return result;
+                });
             }
 
             [DllImport("rl.net.native.dll")]
@@ -184,7 +198,10 @@ namespace Rl.Net {
             {
                 get
                 {
-                    return GetRankingEnumeratorCurrent(this.NativeHandle);
+                    ActionProbability result = GetRankingEnumeratorCurrent(this.DangerousGetHandle());
+
+                    GC.KeepAlive(this);
+                    return result;
                 }
             }
 
@@ -196,14 +213,15 @@ namespace Rl.Net {
                 if (this.initialState)
                 {
                     this.initialState = false;
-                    result = RankingEnumeratorInit(this.NativeHandle);
+                    result = RankingEnumeratorInit(this.DangerousGetHandle());
                 }
                 else
                 {
-                    result = RankingEnumeratorMoveNext(this.NativeHandle);
+                    result = RankingEnumeratorMoveNext(this.DangerousGetHandle());
                 }
 
                 // The contract of result is to return 1 if true, 0 if false.
+                GC.KeepAlive(this);
                 return result == 1;
             }
 

--- a/bindings/cs/rl.net/RankingResponse.cs
+++ b/bindings/cs/rl.net/RankingResponse.cs
@@ -131,7 +131,7 @@ namespace Rl.Net {
             }
 
             GC.KeepAlive(this);
-            return true;
+            return success;
         }
 
         public long ChosenAction
@@ -171,7 +171,7 @@ namespace Rl.Net {
                 {
                     IntPtr result = CreateRankingEnumeratorAdapter(rankingResponse.DangerousGetHandle());
 
-                    GC.KeepAlive(rankingResponse); // TODO: Is this one necessary, or does it live on the heap inside of the delegate?
+                    GC.KeepAlive(rankingResponse); // Extend the lifetime of this handle because the delegate (and its data) is not stored on the heap.
                     return result;
                 });
             }


### PR DESCRIPTION
Right now `LiveModel`, which uses `SafeHandle`, is not thread safe. Specifically, there is a race condition under which the underlying native objects can be auto-finalized while the native method is running due to the way object lifecycle tracking works. The "safe" way to use `SafeHandle` is to rely on P/Invoke to marshal it into an `IntPtr`. This, however, has overhead, and we would like to make this optional. The minimal "safe" thing to do is ensure the "this" pointer does not become "unreachable" until after the native calls return. This is done via a `GC.KeepAlive(this)` call.

To be properly thread safe, the underlying dangerous calls need to be wrapped by `DangerousAddRef` / `DangerousRelease`. This is done by the `LiveModelThreadSafe` class. Note that in this mode, we rely on `SafeHandle`'s critical finalizer to ensure that the underlying object gets properly disposed.

This also removes `NativeObject.NativeHandle`, in favour of expecting callers to use `DangerousXYZ()` methods, if doing dangrous operations.