### PR TITLE
Create safe_vw shared instance on initialization of safe vw factory.

### DIFF
--- a/rlclientlib/vw_model/safe_vw.cc
+++ b/rlclientlib/vw_model/safe_vw.cc
@@ -251,27 +251,23 @@ bool safe_vw::is_compatible(const std::string& args) const {
 }
 
 safe_vw_factory::safe_vw_factory(const std::string& command_line)
-  : _command_line(command_line)
-{}
+{
+	_safe_vw = std::make_shared<safe_vw>(command_line);
+}
 
 safe_vw_factory::safe_vw_factory(const model_management::model_data& master_data)
-  : _master_data(master_data)
-  {}
+{
+	_safe_vw = std::make_shared<safe_vw>(master_data.data(), master_data.data_sz());
+}
 
 safe_vw_factory::safe_vw_factory(const model_management::model_data&& master_data)
-  : _master_data(master_data)
-  {}
+{
+	_safe_vw = std::make_shared<safe_vw>(master_data.data(), master_data.data_sz());
+}
 
-  safe_vw* safe_vw_factory::operator()()
-  {
-    if (_master_data.data())
-    {
-      // Construct new vw object from raw model data.
-      return new safe_vw(_master_data.data(), _master_data.data_sz());
-    }
-    else
-    {
-      return new safe_vw(_command_line);
-    }
-  }
+safe_vw* safe_vw_factory::operator()()
+{
+    return new safe_vw(_safe_vw);
+}
+
 }

--- a/rlclientlib/vw_model/safe_vw.h
+++ b/rlclientlib/vw_model/safe_vw.h
@@ -35,8 +35,7 @@ namespace reinforcement_learning {
   };
 
   class safe_vw_factory {
-    model_management::model_data _master_data;
-    std::string _command_line;
+	std::shared_ptr<safe_vw> _safe_vw;
 
   public:
     // model_data is copied and stored in the factory object.


### PR DESCRIPTION
Currently, if the model data is corrupt, safe vw factory throws an exception when trying to create the safe vw instance. 

Now, moving the user input validation in the constructor by creating a shared safe_vw instance on safe vw factory initialization method. Shared pointer will get auto deleted when no longer in use by the vw pool. 