### PR TITLE
Update VW Version to a496fb9

### DIFF
--- a/rlclientlib/CMakeLists.txt
+++ b/rlclientlib/CMakeLists.txt
@@ -121,7 +121,7 @@ target_include_directories( rlclientlib
                             ${FLATBUFFERS_INCLUDE_DIRS}
                             ${CMAKE_CURRENT_SOURCE_DIR}/../ext_libs/date
                             )
-target_link_libraries(rlclientlib PUBLIC Boost::system vw OpenSSL::SSL OpenSSL::Crypto cpprestsdk::cpprest PRIVATE rapidjson)
+target_link_libraries(rlclientlib PUBLIC Boost::system vw OpenSSL::SSL OpenSSL::Crypto cpprestsdk::cpprest PRIVATE RapidJSON)
 # Consuming Boost uuid requires BCrypt, normally this is automatically linked but vcpkg turns this feature off.
 if(WIN32)
   target_link_libraries(rlclientlib PUBLIC bcrypt)


### PR DESCRIPTION
_Moves from [cb914a038fdb238bc577257b3328c63e02ca74aa](https://github.com/VowpalWabbit/vowpal_wabbit/commit/cb914a038fdb238bc577257b3328c63e02ca74aa) to [a496fb9a0de250ca1dab9cb8d7bc3827e1ce8de1](https://github.com/VowpalWabbit/vowpal_wabbit/commit/a496fb9a0de250ca1dab9cb8d7bc3827e1ce8de1)_

Updates:
* Add chain hash option (https://github.com/VowpalWabbit/vowpal_wabbit/pull/2214)
* Allow overriding --epsilon value from model file (https://github.com/VowpalWabbit/vowpal_wabbit/pull/2277)
* Deprecate "-q:" (https://github.com/VowpalWabbit/vowpal_wabbit/pull/2252)
* Distributionally Robust CB (https://github.com/VowpalWabbit/vowpal_wabbit/pull/2203)

Fixes:
* Support interpreting the string NaN as a float nan in dsjson (https://github.com/VowpalWabbit/vowpal_wabbit/pull/2256)
   > This prevents a crash in this case
* Multiline parsing in python (https://github.com/VowpalWabbit/vowpal_wabbit/pull/2259)
* Fix segfault when reading from cache, using interactions and audit (https://github.com/VowpalWabbit/vowpal_wabbit/pull/2250)
   > -q :: is the correct way to do this, now
* Performance fixes (https://github.com/VowpalWabbit/vowpal_wabbit/pull/2220)
* Reduce probability of overflow (https://github.com/VowpalWabbit/vowpal_wabbit/pull/2217)
* Upgrade Newtonsoft.Json in vw_cli (https://github.com/VowpalWabbit/vowpal_wabbit/pull/2215)
* Fix delete behavior for examples created using parse function (https://github.com/VowpalWabbit/vowpal_wabbit/pull/2206)
* Fix predict affecting model state when in library mode (https://github.com/VowpalWabbit/vowpal_wabbit/pull/2190)

+ Other smaller fixes