### PR TITLE
Update VW Submodule

### DIFF
--- a/include/future_compat.h
+++ b/include/future_compat.h
@@ -2,18 +2,18 @@
 
 #if __cplusplus >= 201103L || defined(_MSC_VER) && (_MSC_VER >= 1900)
 
-#if __cplusplus >= 201402L || defined(_MSC_VER) && (_MSC_VER >= 1910)
+#if __cplusplus >= 201402L || defined(_MSC_VER) && (_MSC_VER >= 1910) && (_MSVC_LANG >= 201402L)
 #define HAS_STD14
 #endif
 
-#if __cplusplus >= 201703L  || defined(_MSC_VER) && (_MSC_VER >= 1914)
+#if __cplusplus >= 201703L  || defined(_MSC_VER) && (_MSC_VER >= 1914) && (_MSVC_LANG >= 201703L)
 #define HAS_STD17
 #endif
 
 #ifdef HAS_STD17
-#define ATTR(name) [[ name ]]
+#define RL_ATTR(name) [[ name ]]
 #else
-#define ATTR(name)
+#define RL_ATTR(name)
 #endif
 
 #ifdef HAS_STD14

--- a/rlclientlib/learning_mode.cc
+++ b/rlclientlib/learning_mode.cc
@@ -1,4 +1,3 @@
-#pragma once
 #include "learning_mode.h"
 #include "constants.h"
 #include <cstring>


### PR DESCRIPTION
This picks up a fix for a crash caused by state corruption when the VW reduction stack throws, and updates for the new IOBuf API.

VW Safety Fixes:
* Implement two new RAII utilities and migrate nn (vowpalwabbit/vowpal_wabbit#2431)
* Add examples to swap_guard and scope_exit (vowpalwabbit/vowpal_wabbit#2441)
* Fix CB state corruption when GD THROWs (vowpalwabbit/vowpal_wabbit#2442)

VW IOBuf refactor:
* IO abstraction refactor - writers and readers (vowpalwabbit/vowpal_wabbit#2412)
* Remove headers no longer needed in io_buf (vowpalwabbit/vowpal_wabbit#2437)

Example fixes:
* Fix some warnings, improve example lifecycle management (vowpalwabbit/vowpal_wabbit#2435)

Misc fixes:
* Change fetching of positional args to be in the options interface (vowpalwabbit/vowpal_wabbit#2418)
* Fix text parser in Python (vowpalwabbit/vowpal_wabbit#2430)
* Widen diff output as as the small width was causing failures on some machines (vowpalwabbit/vowpal_wabbit#2429)
* Fix label name in bug_report (vowpalwabbit/vowpal_wabbit#2438)
* Fix warnings in unit test project (vowpalwabbit/vowpal_wabbit#2439)