### PR TITLE
Fix clarius not working if you only have 2019.

### DIFF
--- a/.scripts/init.cmd
+++ b/.scripts/init.cmd
@@ -13,8 +13,12 @@ IF NOT DEFINED vstestPath (
 
 IF NOT DEFINED msbuildPath (
     IF NOT EXIST "%VsInstallDir%\MSBuild\15.0\Bin\MSBuild.exe" (
-        ECHO ERROR: MsBuild couldn't be found
-        EXIT /b 1
+        IF EXIST "%VsInstallDir%\MSBuild\Current\Bin\MSBuild.exe" (
+            SET "msBuildPath=%VsInstallDir%\MSBuild\Current\Bin\MSBuild.exe"
+        ) else (
+            ECHO ERROR: MsBuild couldn't be found
+            EXIT /b 1
+        )
     ) ELSE (
         SET "msBuildPath=%VsInstallDir%\MSBuild\15.0\Bin\MSBuild.exe"
     )

--- a/bindings/cs/rl.net.cli/rl.net.cli.csproj
+++ b/bindings/cs/rl.net.cli/rl.net.cli.csproj
@@ -19,6 +19,10 @@
     <ProjectReference Include="..\rl.net\rl.net.csproj" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <TextTransformPath>$(DevEnvDir)\TextTransform.exe</TextTransformPath>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Clarius.TransformOnBuild" Version="1.22.0">
       <PrivateAssets>all</PrivateAssets>

--- a/bindings/cs/rl.net/rl.net.csproj
+++ b/bindings/cs/rl.net/rl.net.csproj
@@ -41,6 +41,10 @@
     </Compile>
   </ItemGroup>
 
+  <PropertyGroup>
+    <TextTransformPath>$(DevEnvDir)\TextTransform.exe</TextTransformPath>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Update="InternalsVisibleToTest.tt">
       <Generator>TextTemplatingFileGenerator</Generator>


### PR DESCRIPTION
This fix I believe is portable to VS2017, but would be great if someone could test it.

With it I can build rlclientlib using the CI scripts.