### PR TITLE
Add LoggingOnly learning mode to rlclientlib

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -77,7 +77,8 @@ namespace reinforcement_learning {  namespace value {
       const char *const NULL_TIME_PROVIDER = "NULL_TIME_PROVIDER";
       const char *const CLOCK_TIME_PROVIDER = "CLOCK_TIME_PROVIDER";
       const char *const LEARNING_MODE_ONLINE = "ONLINE";
-      const char *const LEARNING_MODE_IMITATION = "IMITATION";
+      const char *const LEARNING_MODE_APPRENTICE = "APPRENTICE";
+      const char *const LEARNING_MODE_LOGGINGONLY = "LOGGINGONLY";
       const bool DEFAULT_MODEL_BACKGROUND_REFRESH = true;
       const int DEFAULT_VW_POOL_INIT_SIZE = 4;
 }}

--- a/include/learning_mode.h
+++ b/include/learning_mode.h
@@ -1,7 +1,7 @@
 /**
-* @brief decision_modes definition.
+* @brief learning_mode definition.
 *
-* @file decision_modes.h
+* @file learning_mode.h
 * @author Chenxi Zhao
 * @date 2020-02-13
 */
@@ -11,7 +11,8 @@ namespace reinforcement_learning {
 
   enum learning_mode {
     ONLINE = 0,
-    IMITATION = 1,
+    APPRENTICE = 1,
+    LOGGINGONLY = 2,
   };
 
   namespace learning {

--- a/rlclientlib/learning_mode.cc
+++ b/rlclientlib/learning_mode.cc
@@ -11,11 +11,14 @@ namespace reinforcement_learning {
   namespace learning {
     learning_mode to_learning_mode(const char* learning_mode)
     {
-      if (_stricmp(learning_mode, value::LEARNING_MODE_IMITATION) == 0) {
-        return IMITATION;
+      if (_stricmp(learning_mode, value::LEARNING_MODE_APPRENTICE) == 0) {
+        return APPRENTICE;
       }
       else if (_stricmp(learning_mode, value::LEARNING_MODE_ONLINE) == 0) {
         return ONLINE;
+      }
+      else if (_stricmp(learning_mode, value::LEARNING_MODE_LOGGINGONLY) == 0) {
+          return LOGGINGONLY;
       }
       else {
         return ONLINE;

--- a/rlclientlib/live_model_impl.cc
+++ b/rlclientlib/live_model_impl.cc
@@ -90,8 +90,8 @@ namespace reinforcement_learning {
 
   int live_model_impl::request_decision(const char* context_json, unsigned int flags, decision_response& resp, api_status* status)
   {
-    if (_learning_mode == IMITATION) {
-      // Imitaion mode is not supported here at this moment
+    if (_learning_mode == APPRENTICE) {
+      // Apprentice mode is not supported here at this moment
       return error_code::not_supported;
     }
 
@@ -429,8 +429,10 @@ namespace reinforcement_learning {
 
   int post_process_rank(ranking_response& response, learning_mode learning_mode) {
     switch (learning_mode) {
-    case IMITATION:
+    case APPRENTICE:
+    case LOGGINGONLY:
       {
+        // In Apprentice or LoggingOnly mode, we keep the order of actions from input
 #ifdef __clang__
         std::vector<action_prob> tmp;
         std::copy(response.begin(), response.end(), std::back_inserter(tmp));

--- a/rlclientlib/live_model_impl.cc
+++ b/rlclientlib/live_model_impl.cc
@@ -36,7 +36,7 @@ namespace reinforcement_learning {
 
   int check_null_or_empty(const char* arg1, const char* arg2, api_status* status);
   int check_null_or_empty(const char* arg1, api_status* status);
-  int post_process_rank(ranking_response& response, learning_mode learning_mode);
+  int reset_action_order(ranking_response& response);
 
   void default_error_callback(const api_status& status, void* watchdog_context) {
     auto watchdog = static_cast<utility::watchdog*>(watchdog_context);
@@ -71,8 +71,19 @@ namespace reinforcement_learning {
     }
     response.set_event_id(event_id);
 
+    if (_learning_mode == LOGGINGONLY)
+    {
+      // Reset the ranked action order before logging
+      RETURN_IF_FAIL(reset_action_order(response));
+    }
+
     RETURN_IF_FAIL(_ranking_logger->log(event_id, context, flags, response, status, _learning_mode));
-    RETURN_IF_FAIL(post_process_rank(response, _learning_mode));
+
+    if (_learning_mode == APPRENTICE)
+    {
+      // Reset the ranked action order after logging
+      RETURN_IF_FAIL(reset_action_order(response));
+    }
 
     // Check watchdog for any background errors. Do this at the end of function so that the work is still done.
     if (_watchdog.has_background_error_been_reported()) {
@@ -126,7 +137,7 @@ namespace reinforcement_learning {
 
     for (int i = 0; i < event_ids.size(); i++)
     {
-      if(event_ids[i] == nullptr)
+      if (event_ids[i] == nullptr)
       {
         event_ids_str[i] = boost::uuids::to_string(boost::uuids::random_generator()()) + std::to_string(_seed_shift);
         event_ids[i] = event_ids_str[i].c_str();
@@ -219,7 +230,7 @@ namespace reinforcement_learning {
     model_management::model_data md;
     RETURN_IF_FAIL(_transport->get_data(md, status));
 
-	  bool model_ready = false;
+    bool model_ready = false;
     RETURN_IF_FAIL(_model->update(md, model_ready, status));
 
     _model_ready = model_ready;
@@ -238,14 +249,14 @@ namespace reinforcement_learning {
     time_provider_factory_t* time_provider_factory
   )
     : _configuration(config),
-      _error_cb(fn, err_context),
-      _data_cb(_handle_model_update, this),
-      _watchdog(&_error_cb),
-      _trace_factory(trace_factory),
-      _t_factory{t_factory},
-      _m_factory{m_factory},
-      _sender_factory{sender_factory},
-      _time_provider_factory{time_provider_factory}
+    _error_cb(fn, err_context),
+    _data_cb(_handle_model_update, this),
+    _watchdog(&_error_cb),
+    _trace_factory(trace_factory),
+    _t_factory{ t_factory },
+    _m_factory{ m_factory },
+    _sender_factory{ sender_factory },
+    _time_provider_factory{ time_provider_factory }
   {
     // If there is no user supplied error callback, supply a default one that does nothing but report unhandled background errors.
     if (fn == nullptr) {
@@ -262,7 +273,7 @@ namespace reinforcement_learning {
   int live_model_impl::init_trace(api_status* status) {
     const auto trace_impl = _configuration.get(name::TRACE_LOG_IMPLEMENTATION, value::NULL_TRACE_LOGGER);
     i_trace* plogger;
-    RETURN_IF_FAIL(_trace_factory->create(&plogger, trace_impl,_configuration, nullptr, status));
+    RETURN_IF_FAIL(_trace_factory->create(&plogger, trace_impl, _configuration, nullptr, status));
     _trace_logger.reset(plogger);
     TRACE_INFO(_trace_logger, "API Tracing initialized");
     _watchdog.set_trace_log(_trace_logger.get());
@@ -318,7 +329,7 @@ namespace reinforcement_learning {
     RETURN_IF_FAIL(_time_provider_factory->create(&observation_time_provider, time_provider_impl, _configuration, _trace_logger.get(), status));
 
     // Create a logger for interactions that will use msg sender to send interaction messages
-    _outcome_logger.reset(new logger::observation_logger(_configuration, outcome_msg_sender, _watchdog, observation_time_provider,&_error_cb));
+    _outcome_logger.reset(new logger::observation_logger(_configuration, outcome_msg_sender, _watchdog, observation_time_provider, &_error_cb));
     RETURN_IF_FAIL(_outcome_logger->init(status));
 
     // Get the name of raw data (as opposed to message) sender for interactions.
@@ -432,7 +443,7 @@ namespace reinforcement_learning {
     // Swap values in first position with values in chosen index
     scode = e::swap_chosen(begin(response), end(response), chosen_index);
 
-    if ( S_EXPLORATION_OK != scode ) {
+    if (S_EXPLORATION_OK != scode) {
       RETURN_ERROR_LS(_trace_logger.get(), status, exploration_error) << "Exploration (Swap) error code: " << scode;
     }
 
@@ -463,11 +474,11 @@ namespace reinforcement_learning {
     // This class manages lifetime of transport
     this->_transport.reset(ptransport);
 
-	  if (_bg_model_proc) {
+    if (_bg_model_proc) {
       // Initialize background process and start downloading models
-	    this->_model_download.reset(new m::model_downloader(ptransport, &_data_cb, _trace_logger.get()));
-	    return _bg_model_proc->init(_model_download.get(), status);
-	  }
+      this->_model_download.reset(new m::model_downloader(ptransport, &_data_cb, _trace_logger.get()));
+      return _bg_model_proc->init(_model_download.get(), status);
+    }
 
     return refresh_model(status);
   }
@@ -491,35 +502,23 @@ namespace reinforcement_learning {
     return error_code::success;
   }
 
-  int post_process_rank(ranking_response& response, learning_mode learning_mode) {
-    switch (learning_mode) {
-    case APPRENTICE:
-    case LOGGINGONLY:
-      {
-        // In Apprentice or LoggingOnly mode, we keep the order of actions from input
+  int reset_action_order(ranking_response& response) {
 #ifdef __clang__
-        std::vector<action_prob> tmp;
-        std::copy(response.begin(), response.end(), std::back_inserter(tmp));
-        std::sort(tmp.begin(), tmp.end(), [](const action_prob& a, const action_prob& b) {
-          return a.action_id < b.action_id;
-        }
-        );
-        std::copy(tmp.begin(), tmp.end(), response.begin());
-#else
-        std::sort(response.begin(), response.end(), [](const action_prob& a, const action_prob& b) {
-          return a.action_id < b.action_id;
-        }
-        );
-#endif
-        response.set_chosen_action_id((*(response.begin())).action_id);
-        break;
-      }
-      default:
-      {
-        // This is to be back-compatible with the config not setting learning mode.
-        break;
-      }
+    std::vector<action_prob> tmp;
+    std::copy(response.begin(), response.end(), std::back_inserter(tmp));
+    std::sort(tmp.begin(), tmp.end(), [](const action_prob& a, const action_prob& b) {
+      return a.action_id < b.action_id;
     }
+    );
+    std::copy(tmp.begin(), tmp.end(), response.begin());
+#else
+    std::sort(response.begin(), response.end(), [](const action_prob& a, const action_prob& b) {
+      return a.action_id < b.action_id;
+    }
+    );
+#endif
+    response.set_chosen_action_id((*(response.begin())).action_id);
+
     return error_code::success;
   }
 }

--- a/rlclientlib/live_model_impl.cc
+++ b/rlclientlib/live_model_impl.cc
@@ -91,8 +91,8 @@ namespace reinforcement_learning {
 
   int live_model_impl::request_decision(const char* context_json, unsigned int flags, decision_response& resp, api_status* status)
   {
-    if (_learning_mode == APPRENTICE) {
-      // Apprentice mode is not supported here at this moment
+    if (_learning_mode == APPRENTICE || _learning_mode == LOGGINGONLY) {
+      // Apprentice mode and LoggingOnly mode are not supported here at this moment
       return error_code::not_supported;
     }
 

--- a/rlclientlib/live_model_impl.cc
+++ b/rlclientlib/live_model_impl.cc
@@ -154,8 +154,8 @@ namespace reinforcement_learning {
 
   int live_model_impl::request_slates_decision(const char * event_id, const char * context_json, unsigned int flags, slates_response& resp, api_status* status)
   {
-    if (_learning_mode == IMITATION) {
-      // Imitaion mode is not supported here at this moment
+    if (_learning_mode == APPRENTICE || _learning_mode == LOGGINGONLY) {
+      // Apprentice mode and LoggingOnly mode are not supported here at this moment
       return error_code::not_supported;
     }
 

--- a/rlclientlib/schema/RankingEvent.fbs
+++ b/rlclientlib/schema/RankingEvent.fbs
@@ -3,7 +3,7 @@ include "Metadata.fbs";
 
 namespace reinforcement_learning.messages.flatbuff;
 
-enum LearningModeType : ubyte { Online, Imitation }
+enum LearningModeType : ubyte { Online, Apprentice, LoggingOnly }
 
 table RankingEvent {
     event_id:string;                 // event IDs

--- a/rlclientlib/serialization/fb_serializer.h
+++ b/rlclientlib/serialization/fb_serializer.h
@@ -38,12 +38,16 @@ namespace reinforcement_learning { namespace logger {
 
       LearningModeType learning_mode_type;
       switch (evt.get_learning_mode()) {
-      case IMITATION: {
-        learning_mode_type = LearningModeType_Imitation;
+      case APPRENTICE: {
+        learning_mode_type = LearningModeType_Apprentice;
         break;
       }
       case ONLINE: {
         learning_mode_type = LearningModeType_Online;
+        break;
+      }
+      case LOGGINGONLY: {
+        learning_mode_type = LearningModeType_LoggingOnly;
         break;
       }
       default:

--- a/unit_test/fb_serializer_test.cc
+++ b/unit_test/fb_serializer_test.cc
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(fb_serializer_ranking_event) {
   const timestamp ts;
   const size_t events_count = 10;
   for (size_t i = 0; i < events_count; ++i) {
-    mode = static_cast<learning_mode>(i % 2);
+    mode = static_cast<learning_mode>(i % 3);
     auto re = ranking_event::choose_rank(event_id.c_str(), context.c_str(), 0, resp, ts, 0.33f, mode);
     serializer.add(re);
   }
@@ -94,11 +94,14 @@ BOOST_AUTO_TEST_CASE(fb_serializer_ranking_event) {
     BOOST_CHECK_EQUAL_COLLECTIONS(event.probabilities()->begin(), event.probabilities()->end(), expected_prob.begin(), expected_prob.end());
     BOOST_CHECK_EQUAL(event.deferred_action(), false);
     BOOST_CHECK_EQUAL(event.pass_probability(), 0.33f);
-    if (i % 2 == 0) {
+    if (i % 3 == 0) {
       BOOST_CHECK_EQUAL(event.learning_mode(), LearningModeType_Online);
     }
+    else if (i % 3 == 1) {
+      BOOST_CHECK_EQUAL(event.learning_mode(), LearningModeType_Apprentice);
+    }
     else {
-      BOOST_CHECK_EQUAL(event.learning_mode(), LearningModeType_Imitation);
+      BOOST_CHECK_EQUAL(event.learning_mode(), LearningModeType_LoggingOnly);
     }
   }
 }

--- a/unit_test/fb_serializer_test.cc
+++ b/unit_test/fb_serializer_test.cc
@@ -70,8 +70,10 @@ BOOST_AUTO_TEST_CASE(fb_serializer_ranking_event) {
 
   const timestamp ts;
   const size_t events_count = 10;
+  const int learning_mode_count = 3;
+
   for (size_t i = 0; i < events_count; ++i) {
-    mode = static_cast<learning_mode>(i % 3);
+    mode = static_cast<learning_mode>(i % learning_mode_count);
     auto re = ranking_event::choose_rank(event_id.c_str(), context.c_str(), 0, resp, ts, 0.33f, mode);
     serializer.add(re);
   }
@@ -94,10 +96,10 @@ BOOST_AUTO_TEST_CASE(fb_serializer_ranking_event) {
     BOOST_CHECK_EQUAL_COLLECTIONS(event.probabilities()->begin(), event.probabilities()->end(), expected_prob.begin(), expected_prob.end());
     BOOST_CHECK_EQUAL(event.deferred_action(), false);
     BOOST_CHECK_EQUAL(event.pass_probability(), 0.33f);
-    if (i % 3 == 0) {
+    if (i % learning_mode_count == 0) {
       BOOST_CHECK_EQUAL(event.learning_mode(), LearningModeType_Online);
     }
-    else if (i % 3 == 1) {
+    else if (i % learning_mode_count == 1) {
       BOOST_CHECK_EQUAL(event.learning_mode(), LearningModeType_Apprentice);
     }
     else {

--- a/unit_test/learning_mode_test.cc
+++ b/unit_test/learning_mode_test.cc
@@ -7,16 +7,28 @@
 #include "learning_mode.h"
 #include "constants.h"
 
-BOOST_AUTO_TEST_CASE(learning_mode_lower_case) {
-  const char* imitation = "imitation";
-  auto mode = reinforcement_learning::learning::to_learning_mode(imitation);
-  BOOST_CHECK_EQUAL(mode, reinforcement_learning::IMITATION);
+BOOST_AUTO_TEST_CASE(learning_mode_apprentice_lower_case) {
+  const char* apprentice = "apprentice";
+  auto mode = reinforcement_learning::learning::to_learning_mode(apprentice);
+  BOOST_CHECK_EQUAL(mode, reinforcement_learning::APPRENTICE);
 }
 
-BOOST_AUTO_TEST_CASE(learning_mode_imitation) {
-  const char* imitation = reinforcement_learning::value::LEARNING_MODE_IMITATION;
-  auto mode = reinforcement_learning::learning::to_learning_mode(imitation);
-  BOOST_CHECK_EQUAL(mode, reinforcement_learning::IMITATION);
+BOOST_AUTO_TEST_CASE(learning_mode_apprentice) {
+  const char* apprentice = reinforcement_learning::value::LEARNING_MODE_APPRENTICE;
+  auto mode = reinforcement_learning::learning::to_learning_mode(apprentice);
+  BOOST_CHECK_EQUAL(mode, reinforcement_learning::APPRENTICE);
+}
+
+BOOST_AUTO_TEST_CASE(learning_mode_loggingonly_lower_case) {
+    const char* logging_only = "loggingonly";
+    auto mode = reinforcement_learning::learning::to_learning_mode(logging_only);
+    BOOST_CHECK_EQUAL(mode, reinforcement_learning::LOGGINGONLY);
+}
+
+BOOST_AUTO_TEST_CASE(learning_mode_loggingonly) {
+    const char* logging_only = reinforcement_learning::value::LEARNING_MODE_LOGGINGONLY;
+    auto mode = reinforcement_learning::learning::to_learning_mode(logging_only);
+    BOOST_CHECK_EQUAL(mode, reinforcement_learning::LOGGINGONLY);
 }
 
 BOOST_AUTO_TEST_CASE(learning_mode_online) {
@@ -26,7 +38,7 @@ BOOST_AUTO_TEST_CASE(learning_mode_online) {
 }
 
 BOOST_AUTO_TEST_CASE(learning_mode_other) {
-  const char* imitation = "other";
-  auto mode = reinforcement_learning::learning::to_learning_mode(imitation);
+  const char* apprentice = "other";
+  auto mode = reinforcement_learning::learning::to_learning_mode(apprentice);
   BOOST_CHECK_EQUAL(mode, reinforcement_learning::ONLINE);
 }

--- a/unit_test/learning_mode_test.cc
+++ b/unit_test/learning_mode_test.cc
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE(learning_mode_online) {
 }
 
 BOOST_AUTO_TEST_CASE(learning_mode_other) {
-  const char* apprentice = "other";
-  auto mode = reinforcement_learning::learning::to_learning_mode(apprentice);
+  const char* other = "other";
+  auto mode = reinforcement_learning::learning::to_learning_mode(other);
   BOOST_CHECK_EQUAL(mode, reinforcement_learning::ONLINE);
 }

--- a/unit_test/live_model_test.cc
+++ b/unit_test/live_model_test.cc
@@ -152,12 +152,43 @@ BOOST_AUTO_TEST_CASE(live_model_ranking_request_online_mode) {
   BOOST_CHECK_EQUAL(status.get_error_msg(), "");
 }
 
-BOOST_AUTO_TEST_CASE(live_model_ranking_request_imitation_mode) {
+BOOST_AUTO_TEST_CASE(live_model_ranking_request_apprentice_mode) {
   //create a simple ds configuration
   u::configuration config;
   cfg::create_from_json(JSON_CFG, config);
   config.set(r::name::EH_TEST, "true");
   config.set(r::name::LEARNING_MODE, r::value::LEARNING_MODE_APPRENTICE);
+
+  r::api_status status;
+
+  //create the ds live_model, and initialize it with the config
+  r::live_model ds = create_mock_live_model(config);
+  BOOST_CHECK_EQUAL(ds.init(&status), err::success);
+
+  const auto event_id = "event_id";
+
+  r::ranking_response response;
+
+  ds.choose_rank(event_id, JSON_CONTEXT_LEARNING, response, &status);
+  BOOST_CHECK_EQUAL(status.get_error_code(), 0);
+  BOOST_CHECK_EQUAL(status.get_error_msg(), "");
+  size_t chosen_action;
+  response.get_chosen_action_id(chosen_action, &status);
+  BOOST_CHECK_EQUAL(chosen_action, 0);
+  int current_expect_action_id = 0;
+  for (auto it = response.begin(); it != response.end(); ++it) {
+    BOOST_CHECK_EQUAL((*it).action_id, current_expect_action_id);
+    current_expect_action_id++;
+  }
+}
+
+
+BOOST_AUTO_TEST_CASE(live_model_ranking_request_loggingonly_mode) {
+  //create a simple ds configuration
+  u::configuration config;
+  cfg::create_from_json(JSON_CFG, config);
+  config.set(r::name::EH_TEST, "true");
+  config.set(r::name::LEARNING_MODE, r::value::LEARNING_MODE_LOGGINGONLY);
 
   r::api_status status;
 

--- a/unit_test/live_model_test.cc
+++ b/unit_test/live_model_test.cc
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE(live_model_ranking_request_imitation_mode) {
   u::configuration config;
   cfg::create_from_json(JSON_CFG, config);
   config.set(r::name::EH_TEST, "true");
-  config.set(r::name::LEARNING_MODE, r::value::LEARNING_MODE_IMITATION);
+  config.set(r::name::LEARNING_MODE, r::value::LEARNING_MODE_APPRENTICE);
 
   r::api_status status;
 

--- a/unit_test/unit_test.vcxproj
+++ b/unit_test/unit_test.vcxproj
@@ -174,6 +174,7 @@
     <ClCompile Include="file_logger_test.cc" />
     <ClCompile Include="json_context_parse_test.cc" />
     <ClCompile Include="json_serializer_test.cc" />
+    <ClCompile Include="learning_mode_test.cc" />
     <ClCompile Include="live_model_test.cc" />
     <ClCompile Include="eventhub_client_test.cc" />
     <ClCompile Include="main.cc" />

--- a/unit_test/unit_test.vcxproj.filters
+++ b/unit_test/unit_test.vcxproj.filters
@@ -113,6 +113,9 @@
     <ClCompile Include="time_tests.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="learning_mode_test.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
Add support for LoggingOnly mode:
1. Add LoggingOnly to LearningMode enum
2. Return response with action order as is from input
3. Use input action order and add LoggingOnly tag to events sent to eventhub. 
4. Rename Imitation to Apprentice
5. Update existing and add new unit tests