### PR TITLE
[IDEA] Use a transparent type to achieve nodiscard semantics

### DIFF
--- a/include/api_status.h
+++ b/include/api_status.h
@@ -10,6 +10,15 @@
 #include <string>
 #include <sstream>
 #include "err_constants.h"
+#include "future_compat.h"
+
+struct RL_ATTR(nodiscard) error_code_no_discard
+{
+  error_code_no_discard(int value) : _value(value) {}
+  operator int() const { return _value; }
+  int value() const { return _value; }
+  int _value;
+};
 
 namespace reinforcement_learning {
   class i_trace;
@@ -73,6 +82,9 @@ namespace reinforcement_learning {
 
     //! return the status when cast to an int
     operator int() const;
+    operator error_code_no_discard() const {
+      return _code;
+    }
 
     //! Error code
     int _code;

--- a/rlclientlib/live_model_impl.cc
+++ b/rlclientlib/live_model_impl.cc
@@ -54,7 +54,7 @@ namespace reinforcement_learning {
     return error_code::success;
   }
 
-  int live_model_impl::choose_rank(const char* event_id, const char* context, unsigned int flags, ranking_response& response,
+  error_code_no_discard live_model_impl::choose_rank(const char* event_id, const char* context, unsigned int flags, ranking_response& response,
     api_status* status) {
     response.clear();
     //clear previous errors if any

--- a/rlclientlib/live_model_impl.h
+++ b/rlclientlib/live_model_impl.h
@@ -25,7 +25,7 @@ namespace reinforcement_learning
 
     int init(api_status* status);
 
-    int choose_rank(const char* event_id, const char* context, unsigned int flags, ranking_response& response, api_status* status);
+    error_code_no_discard choose_rank(const char* event_id, const char* context, unsigned int flags, ranking_response& response, api_status* status);
     //here the event_id is auto-generated
     int choose_rank(const char* context, unsigned int flags, ranking_response& response, api_status* status);
     int request_decision(const char* context_json, unsigned int flags, decision_response& resp, api_status* status);


### PR DESCRIPTION
This is just an idea as a code sample.

[[nodiscard]] is very helpful, especially for error code values. However, since the interface just uses ints right now we can't easily make use of it. There are several ways we could:

1. Mark everything [[nodiscard]] manually
    - Cumbersome
2. Use a macro such as `API` -> `[[nodiscard]] int`
    - Still just a raw int
    - It's a macro...
3. Use an enum that is marked [[nodiscard]]
   - I am a big fan of using enums for error codes
4. Use a transparent type that is marked [[nodiscard]]
   - This has implicit operators that means it behaves similar to an int but can't be discarded as easily
   - It does use implicits though which isn't great
