### PR TITLE
Add dedup_dict class that will later be used by the dedup work.

### DIFF
--- a/rlclientlib/CMakeLists.txt
+++ b/rlclientlib/CMakeLists.txt
@@ -25,6 +25,7 @@ set(PROJECT_SOURCES
   console_tracer.cc
   continuous_action_response.cc
   decision_response.cc
+  dedup.cc
   error_callback_fn.cc
   factory_resolver.cc
   live_model_impl.cc
@@ -98,6 +99,7 @@ set(PROJECT_PUBLIC_HEADERS
 set(PROJECT_PRIVATE_HEADERS
   azure_factories.h
   console_tracer.h
+  dedup.h
   live_model_impl.h
   logger/async_batcher.h
   logger/event_logger.h

--- a/rlclientlib/CMakeLists.txt
+++ b/rlclientlib/CMakeLists.txt
@@ -113,6 +113,7 @@ set(PROJECT_PRIVATE_HEADERS
   moving_queue.h
   generic_event.h
   ranking_event.h
+  rl_string_view.h
   sampling.h
   serialization/fb_serializer.h
   serialization/json_serializer.h

--- a/rlclientlib/dedup.cc
+++ b/rlclientlib/dedup.cc
@@ -19,13 +19,13 @@ namespace reinforcement_learning
     return uniform_hash(start, size, 0);
   }
 
-  dedup_dict::action_id_t dedup_dict::add_action(const char *start, size_t size)
+  dedup_dict::action_id_t dedup_dict::add_action(const char *start, size_t length)
   {
-    action_id_t hash = hash_content(start, size);
+    action_id_t hash = hash_content(start, length);
     auto it = _entries.find(hash);
     if (it == _entries.end())
     {
-      _entries.insert({ hash, dict_entry(start, size) });
+      _entries.insert({ hash, dict_entry(start, length) });
     }
     else
     {
@@ -34,9 +34,9 @@ namespace reinforcement_learning
     return hash;
   }
 
-  bool dedup_dict::remove_action(action_id_t hash)
+  bool dedup_dict::remove_action(action_id_t aid)
   {
-    auto it = _entries.find(hash);
+    auto it = _entries.find(aid);
     if (it == _entries.end())
       return false;
 
@@ -45,6 +45,14 @@ namespace reinforcement_learning
       _entries.erase(it);
 
     return true;
+  }
+
+  string_view dedup_dict::get_action(action_id_t aid)
+  {
+    auto it = _entries.find(aid);
+    if (it == _entries.end())
+      return string_view();
+    return string_view(it->second._content.data(), it->second._length);
   }
 
   int dedup_dict::transform_payload(const char* payload, std::string& edited_payload, action_list_t& action_ids, api_status* status)

--- a/rlclientlib/dedup.cc
+++ b/rlclientlib/dedup.cc
@@ -47,7 +47,7 @@ namespace reinforcement_learning
     return true;
   }
 
-  string_view dedup_dict::get_action(action_id_t aid)
+  string_view dedup_dict::get_action(action_id_t aid) const
   {
     auto it = _entries.find(aid);
     if (it == _entries.end())
@@ -55,7 +55,7 @@ namespace reinforcement_learning
     return string_view(it->second._content.data(), it->second._length);
   }
 
-  int dedup_dict::transform_payload(const char* payload, std::string& edited_payload, action_list_t& action_ids, api_status* status)
+  int dedup_dict::transform_payload_and_add_actions(const char* payload, std::string& edited_payload, action_list_t& action_ids, api_status* status)
   {
     utility::ContextInfo context_info;
     RETURN_IF_FAIL(utility::get_context_info(payload, context_info, nullptr, status));

--- a/rlclientlib/dedup.cc
+++ b/rlclientlib/dedup.cc
@@ -57,8 +57,8 @@ namespace reinforcement_learning
 
   int dedup_dict::transform_payload_and_add_actions(const char* payload, std::string& edited_payload, action_list_t& action_ids, api_status* status)
   {
-    utility::ContextInfo context_info;
-    RETURN_IF_FAIL(utility::get_context_info(payload, context_info, nullptr, status));
+    u::ContextInfo context_info;
+    RETURN_IF_FAIL(u::get_context_info(payload, context_info, nullptr, status));
 
     edited_payload = payload;
     action_ids.clear();

--- a/rlclientlib/dedup.cc
+++ b/rlclientlib/dedup.cc
@@ -1,0 +1,74 @@
+#include "dedup.h"
+#include "hash.h"
+#include "utility/context_helper.h"
+
+#include <sstream>
+
+namespace reinforcement_learning
+{
+  namespace u = utility;
+
+  dedup_dict::dict_entry::dict_entry(const char *data, size_t length) : _count(1),
+                                                                        _length(length),
+                                                                        _content(data, data + length)
+  {
+  }
+
+  static dedup_dict::action_id_t hash_content(const char *start, size_t size)
+  {
+    return uniform_hash(start, size, 0);
+  }
+
+  dedup_dict::action_id_t dedup_dict::add_action(const char *start, size_t size)
+  {
+    action_id_t hash = hash_content(start, size);
+    auto it = _entries.find(hash);
+    if (it == _entries.end())
+    {
+      _entries.insert({ hash, dict_entry(start, size) });
+    }
+    else
+    {
+      ++it->second._count;
+    }
+    return hash;
+  }
+
+  bool dedup_dict::remove_action(action_id_t hash)
+  {
+    auto it = _entries.find(hash);
+    if (it == _entries.end())
+      return false;
+
+    --it->second._count;
+    if (!it->second._count)
+      _entries.erase(it);
+
+    return true;
+  }
+
+  int dedup_dict::transform_payload(const char* payload, std::string& edited_payload, action_list_t& action_ids, api_status* status)
+  {
+    utility::ContextInfo context_info;
+    RETURN_IF_FAIL(utility::get_context_info(payload, context_info, nullptr, status));
+
+    edited_payload = payload;
+    action_ids.clear();
+    action_ids.reserve(context_info.actions.size());
+
+    int edit_offset = 0;
+    for (auto &p : context_info.actions)
+    {
+      auto hash = add_action(&payload[p.first], p.second);
+      action_ids.push_back(hash);
+      std::stringstream replacement("{\"__aid\":");
+      replacement << hash << "}";
+      edited_payload.replace(p.first - edit_offset, p.second, replacement.str());
+
+      //adjust the edit position based on how many bytes were deleted.
+      edit_offset += p.second - replacement.tellp();
+    }
+
+    return error_code::success;
+  }
+} // namespace reinforcement_learning

--- a/rlclientlib/dedup.cc
+++ b/rlclientlib/dedup.cc
@@ -61,7 +61,8 @@ namespace reinforcement_learning
     {
       auto hash = add_action(&payload[p.first], p.second);
       action_ids.push_back(hash);
-      std::stringstream replacement("{\"__aid\":");
+      std::stringstream replacement;
+      replacement << "{\"__aid\":";
       replacement << hash << "}";
       edited_payload.replace(p.first - edit_offset, p.second, replacement.str());
 

--- a/rlclientlib/dedup.h
+++ b/rlclientlib/dedup.h
@@ -25,9 +25,9 @@ public:
     //! Returns the action id of the action described by [start, start+size[
     action_id_t add_action(const char* start, size_t length);
     //! Return a string_view of the action content, or an empty view if not found
-    string_view get_action(action_id_t aid);
+    string_view get_action(action_id_t aid) const;
 
-    int transform_payload(const char* payload, std::string& edited_payload, action_list_t& action_ids, api_status* status);
+    int transform_payload_and_add_actions(const char* payload, std::string& edited_payload, action_list_t& action_ids, api_status* status);
 private:
     struct dict_entry {
         size_t _count;

--- a/rlclientlib/dedup.h
+++ b/rlclientlib/dedup.h
@@ -9,8 +9,8 @@
 namespace reinforcement_learning {
 class dedup_dict {
 public:
-    typedef uint64_t action_id_t;
-    typedef std::vector<action_id_t> action_list_t;
+    using action_id_t = uint64_t;
+    using action_list_t = std::vector<action_id_t>;
     dedup_dict() = default;
 
     dedup_dict(const dedup_dict&) = delete;
@@ -22,7 +22,7 @@ public:
 
     //! Returns true if the action was found. This doesn't tell the ref count status of that action
     bool remove_action(action_id_t aid);
-    //! Returns the action id of the action described by [start, start+size[
+    //! Returns the action id of the action described by [start, start+length[
     action_id_t add_action(const char* start, size_t length);
     //! Return a string_view of the action content, or an empty view if not found
     string_view get_action(action_id_t aid) const;

--- a/rlclientlib/dedup.h
+++ b/rlclientlib/dedup.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "api_status.h"
+#include "rl_string_view.h"
 
 #include <vector>
 #include <unordered_map>
@@ -19,7 +20,13 @@ public:
     dedup_dict& operator=(dedup_dict&&) = default;
     ~dedup_dict() = default;
 
-    bool remove_action(action_id_t hash); 
+    //! Returns true if the action was found. This doesn't tell the ref count status of that action
+    bool remove_action(action_id_t aid);
+    //! Returns the action id of the action described by [start, start+size[
+    action_id_t add_action(const char* start, size_t length);
+    //! Return a string_view of the action content, or an empty view if not found
+    string_view get_action(action_id_t aid);
+
     int transform_payload(const char* payload, std::string& edited_payload, action_list_t& action_ids, api_status* status);
 private:
     struct dict_entry {
@@ -29,7 +36,6 @@ private:
 
         dict_entry(const char* data, size_t length);
     };
-    action_id_t add_action(const char* start, size_t size);
     std::unordered_map<action_id_t, dict_entry> _entries;
 };
 

--- a/rlclientlib/dedup.h
+++ b/rlclientlib/dedup.h
@@ -1,0 +1,36 @@
+#pragma once
+#include "api_status.h"
+
+#include <vector>
+#include <unordered_map>
+
+
+namespace reinforcement_learning {
+class dedup_dict {
+public:
+    typedef uint64_t action_id_t;
+    typedef std::vector<action_id_t> action_list_t;
+    dedup_dict() = default;
+
+    dedup_dict(const dedup_dict&) = delete;
+    dedup_dict& operator=(const dedup_dict&) = delete;
+
+    dedup_dict(dedup_dict&&) = default;
+    dedup_dict& operator=(dedup_dict&&) = default;
+    ~dedup_dict() = default;
+
+    bool remove_action(action_id_t hash); 
+    int transform_payload(const char* payload, std::string& edited_payload, action_list_t& action_ids, api_status* status);
+private:
+    struct dict_entry {
+        size_t _count;
+        size_t _length;
+        std::vector<char> _content;
+
+        dict_entry(const char* data, size_t length);
+    };
+    action_id_t add_action(const char* start, size_t size);
+    std::unordered_map<action_id_t, dict_entry> _entries;
+};
+
+}

--- a/rlclientlib/rl_string_view.h
+++ b/rlclientlib/rl_string_view.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "hashstring.h"
+#include <boost/version.hpp>
+
+#if BOOST_VERSION < 106100
+#include <boost/utility/string_ref.hpp>
+namespace reinforcement_learning
+{
+using string_view = boost::string_ref;
+}
+#else
+#include <boost/utility/string_view.hpp>
+namespace reinforcement_learning
+{
+using string_view = boost::string_view;
+}
+#endif

--- a/rlclientlib/rlclientlib.vcxproj
+++ b/rlclientlib/rlclientlib.vcxproj
@@ -238,6 +238,7 @@ $(flatcPath) -o $(SolutionDir)rlclientlib\generated\v2\ --cpp $(SolutionDir)rlcl
     <ClInclude Include="live_model_impl.h" />
     <ClInclude Include="error_callback_fn.h" />
     <ClInclude Include="ranking_event.h" />
+    <ClInclude Include="dedup.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="generic_event.cc" />
@@ -272,6 +273,7 @@ $(flatcPath) -o $(SolutionDir)rlclientlib\generated\v2\ --cpp $(SolutionDir)rlcl
     <ClCompile Include="ranking_event.cc" />
     <ClCompile Include="ranking_response.cc" />
     <ClCompile Include="decision_response.cc" />
+    <ClCompile Include="dedup.cc" />
     <ClCompile Include="continuous_action_response.cc" />
     <ClCompile Include="logger\async_batcher.cc" />
     <ClCompile Include="azure_factories.cc" />

--- a/rlclientlib/rlclientlib.vcxproj.filters
+++ b/rlclientlib/rlclientlib.vcxproj.filters
@@ -48,6 +48,7 @@
     <ClCompile Include="logger\logger_facade.cc" />
     <ClCompile Include="serialization\payload_serializer.cc" />
     <ClCompile Include="generic_event.cc" />
+    <ClCompile Include="dedup.cc" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\api_status.h" />
@@ -118,6 +119,7 @@
     <ClInclude Include="logger\logger_facade.h" />
     <ClInclude Include="serialization\payload_serializer.h" />
     <ClInclude Include="generic_event.h" />
+    <ClInclude Include="dedup.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/rlclientlib/utility/context_helper.cc
+++ b/rlclientlib/utility/context_helper.cc
@@ -103,7 +103,7 @@ namespace reinforcement_learning { namespace utility {
       --_level;
 
       if((_is_multi | _is_slots) && _level == 1 && _array_level == 1) {
-        size_t item_end = _is.Tell() - 1;
+        size_t item_end = _is.Tell() - _item_start;
         if(_is_multi)
           _info.actions.push_back(std::make_pair(_item_start, item_end));
         if(_is_slots)

--- a/rlclientlib/utility/context_helper.h
+++ b/rlclientlib/utility/context_helper.h
@@ -11,7 +11,7 @@ namespace reinforcement_learning {
 
     //! This struct collects all sort of relevant data we need about a context json.
     struct ContextInfo {
-      //! Each pair is the start and end offsets of a JSON object. IE the offsets to '{' and '}'
+      //! Each pair is the start offset and length of a JSON object. IE, the range covers '{' to '}'
       typedef std::vector<std::pair<size_t, size_t>> index_vector_t;
 
       //! The index to each element in the _multi array

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(rltest
   data_buffer_test.cc
   data_callback_test.cc
   err_callback_test.cc
+  dedup_test.cc
   event_queue_test.cc
   eventhub_client_test.cc
   explore_test.cc

--- a/unit_test/dedup_test.cc
+++ b/unit_test/dedup_test.cc
@@ -1,30 +1,65 @@
 #define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
-#   define BOOST_TEST_MODULE Main
+#define BOOST_TEST_MODULE Main
 #endif
 
 #include <boost/test/unit_test.hpp>
 #include "dedup.h"
 
-
-
 namespace r = reinforcement_learning;
 namespace err = reinforcement_learning::error_code;
 
-BOOST_AUTO_TEST_CASE(dedup_remove_unknown_action) {
-    r::dedup_dict dict;
-
-    BOOST_CHECK_EQUAL(false, dict.remove_action(1));
+BOOST_AUTO_TEST_CASE(dedup_remove_unknown_action)
+{
+  r::dedup_dict dict;
+  BOOST_CHECK_EQUAL(false, dict.remove_action(1));
 }
 
-BOOST_AUTO_TEST_CASE(dedup_bad_json) {
-    r::dedup_dict dict;
-    const char *payload = "{ invalid }";
-    std::string p_out;
-    r::dedup_dict::action_list_t a_out;
+BOOST_AUTO_TEST_CASE(dedup_bad_json)
+{
+  r::dedup_dict dict;
+  const char *payload = "{ invalid }";
+  std::string p_out;
+  r::dedup_dict::action_list_t a_out;
 
-    BOOST_CHECK_EQUAL(err::json_parse_error, dict.transform_payload(payload, p_out, a_out, nullptr));
+  BOOST_CHECK_EQUAL(err::json_parse_error, dict.transform_payload(payload, p_out, a_out, nullptr));
 }
 
+BOOST_AUTO_TEST_CASE(dedup_simple_json)
+{
+  r::dedup_dict dict;
+  std::string payload = R"(
+    {
+      "s_": "1",
+      "_multi": [
+        { "b_": "1" },
+        { "b_": "2" }
+      ],
+      "_slots": [ { "a": 10 }, { "b": 20 } ]
+    })";
 
+  std::string p_out;
+  r::dedup_dict::action_list_t a_out;
 
+  BOOST_CHECK_EQUAL(err::success, dict.transform_payload(payload.c_str(), p_out, a_out, nullptr));
+  BOOST_CHECK_EQUAL(2, a_out.size());
+  BOOST_CHECK_EQUAL(989852256, a_out[0]);
+  BOOST_CHECK_EQUAL(178626470, a_out[1]);
+
+  std::string transformed_payload = R"(
+    {
+      "s_": "1",
+      "_multi": [
+        {"__aid":989852256},
+        {"__aid":178626470}
+      ],
+      "_slots": [ { "a": 10 }, { "b": 20 } ]
+    })";
+  BOOST_CHECK_EQUAL(transformed_payload, p_out);
+
+  BOOST_CHECK_EQUAL(true, dict.remove_action(989852256));
+  BOOST_CHECK_EQUAL(true, dict.remove_action(178626470));
+  BOOST_CHECK_EQUAL(false, dict.remove_action(989852256));
+  BOOST_CHECK_EQUAL(false, dict.remove_action(178626470));
+
+}

--- a/unit_test/dedup_test.cc
+++ b/unit_test/dedup_test.cc
@@ -1,0 +1,30 @@
+#define BOOST_TEST_DYN_LINK
+#ifdef STAND_ALONE
+#   define BOOST_TEST_MODULE Main
+#endif
+
+#include <boost/test/unit_test.hpp>
+#include "dedup.h"
+
+
+
+namespace r = reinforcement_learning;
+namespace err = reinforcement_learning::error_code;
+
+BOOST_AUTO_TEST_CASE(dedup_remove_unknown_action) {
+    r::dedup_dict dict;
+
+    BOOST_CHECK_EQUAL(false, dict.remove_action(1));
+}
+
+BOOST_AUTO_TEST_CASE(dedup_bad_json) {
+    r::dedup_dict dict;
+    const char *payload = "{ invalid }";
+    std::string p_out;
+    r::dedup_dict::action_list_t a_out;
+
+    BOOST_CHECK_EQUAL(err::json_parse_error, dict.transform_payload(payload, p_out, a_out, nullptr));
+}
+
+
+

--- a/unit_test/dedup_test.cc
+++ b/unit_test/dedup_test.cc
@@ -15,6 +15,36 @@ BOOST_AUTO_TEST_CASE(dedup_remove_unknown_action)
   BOOST_CHECK_EQUAL(false, dict.remove_action(1));
 }
 
+BOOST_AUTO_TEST_CASE(dedup_add_remove_action)
+{
+  r::dedup_dict dict;
+  auto id = dict.add_action("abc", 3);
+  auto id2 = dict.add_action("abc", 3);
+
+  BOOST_CHECK_EQUAL(id, id2);
+
+  BOOST_CHECK_EQUAL(true, dict.remove_action(id));
+  BOOST_CHECK_EQUAL(true, dict.remove_action(id));
+  BOOST_CHECK_EQUAL(false, dict.remove_action(id));
+}
+
+BOOST_AUTO_TEST_CASE(dedup_add_empty_action)
+{
+  r::dedup_dict dict;
+  auto id = dict.add_action("", 0);
+  BOOST_CHECK_EQUAL(true, dict.remove_action(id));
+}
+
+BOOST_AUTO_TEST_CASE(dedup_add_get_action)
+{
+  r::dedup_dict dict;
+  auto id = dict.add_action("{abc}", 5);
+  auto str = dict.get_action(id);
+
+  BOOST_CHECK_EQUAL(5, str.size());
+  BOOST_CHECK_EQUAL("{abc}", str.to_string());
+}
+
 BOOST_AUTO_TEST_CASE(dedup_bad_json)
 {
   r::dedup_dict dict;
@@ -61,5 +91,4 @@ BOOST_AUTO_TEST_CASE(dedup_simple_json)
   BOOST_CHECK_EQUAL(true, dict.remove_action(178626470));
   BOOST_CHECK_EQUAL(false, dict.remove_action(989852256));
   BOOST_CHECK_EQUAL(false, dict.remove_action(178626470));
-
 }

--- a/unit_test/dedup_test.cc
+++ b/unit_test/dedup_test.cc
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(dedup_bad_json)
   std::string p_out;
   r::dedup_dict::action_list_t a_out;
 
-  BOOST_CHECK_EQUAL(err::json_parse_error, dict.transform_payload(payload, p_out, a_out, nullptr));
+  BOOST_CHECK_EQUAL(err::json_parse_error, dict.transform_payload_and_add_actions(payload, p_out, a_out, nullptr));
 }
 
 BOOST_AUTO_TEST_CASE(dedup_simple_json)
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(dedup_simple_json)
   std::string p_out;
   r::dedup_dict::action_list_t a_out;
 
-  BOOST_CHECK_EQUAL(err::success, dict.transform_payload(payload.c_str(), p_out, a_out, nullptr));
+  BOOST_CHECK_EQUAL(err::success, dict.transform_payload_and_add_actions(payload.c_str(), p_out, a_out, nullptr));
   BOOST_CHECK_EQUAL(2, a_out.size());
   BOOST_CHECK_EQUAL(989852256, a_out[0]);
   BOOST_CHECK_EQUAL(178626470, a_out[1]);

--- a/unit_test/json_context_parse_test.cc
+++ b/unit_test/json_context_parse_test.cc
@@ -154,12 +154,12 @@ BOOST_AUTO_TEST_CASE(slots_before_multi) {
 
 std::string get_action_str(const std::string &context, rlutil::ContextInfo& info, int idx)
 {
-  return context.substr(info.actions[idx].first, info.actions[idx].second - info.actions[idx].first + 1);
+  return context.substr(info.actions[idx].first, info.actions[idx].second);
 }
 
 std::string get_slot_str(const std::string &context, rlutil::ContextInfo& info, int idx)
 {
-  return context.substr(info.slots[idx].first, info.slots[idx].second - info.slots[idx].first + 1);
+  return context.substr(info.slots[idx].first, info.slots[idx].second);
 }
 
 BOOST_AUTO_TEST_CASE(get_context_info_test) {
@@ -184,7 +184,7 @@ BOOST_AUTO_TEST_CASE(get_context_info_test) {
   BOOST_CHECK_EQUAL(3, info.actions.size());
   BOOST_CHECK_EQUAL(4, info.slots.size());
   BOOST_CHECK_EQUAL('{', context[info.actions[0].first]);
-  BOOST_CHECK_EQUAL('}', context[info.actions[0].second]);
+  BOOST_CHECK_EQUAL('}', context[info.actions[0].first + info.actions[0].second - 1]);
 
   BOOST_CHECK_EQUAL("{\"_text\":\"elections maine\", \"Source\":\"TV\"}", get_action_str(context, info, 0));
   BOOST_CHECK_EQUAL("{\"Source\":\"www\", \"topic\":4, \"_label\":\"2:3:.3\"}", get_action_str(context, info, 1));


### PR DESCRIPTION
This type will be used during serialization at two spots.

Before an event is serialized into a generic_event we process the json payload and include the
resulting action_list into the generated generic_event.

During batch creation we use get_action and remove_action to compute the per batch dictionary
and unregister actions as events sink into the batch.

Next is an adaptative per-batch dictionary builder and schema change.