### PR TITLE
Introduce i_async_batcher and i_payload_transformer interfaces.

### DIFF
--- a/rlclientlib/live_model_impl.cc
+++ b/rlclientlib/live_model_impl.cc
@@ -379,7 +379,7 @@ namespace reinforcement_learning {
     RETURN_IF_FAIL(_time_provider_factory->create(&ranking_time_provider, time_provider_impl, _configuration, _trace_logger.get(), status));
 
     // Create a logger for interactions that will use msg sender to send interaction messages
-    _interaction_logger.reset(new logger::interaction_logger_facade(_model->model_type(), _configuration, ranking_msg_sender, _watchdog, ranking_time_provider, &_error_cb));
+    _interaction_logger.reset(new logger::interaction_logger_facade(_model->model_type(), _configuration, ranking_msg_sender, _watchdog, ranking_time_provider, nullptr, &_error_cb));
     RETURN_IF_FAIL(_interaction_logger->init(status));
 
     // Get the name of raw data (as opposed to message) sender for observations.
@@ -400,7 +400,7 @@ namespace reinforcement_learning {
     RETURN_IF_FAIL(_time_provider_factory->create(&observation_time_provider, time_provider_impl, _configuration, _trace_logger.get(), status));
 
     // Create a logger for interactions that will use msg sender to send interaction messages
-    _outcome_logger.reset(new logger::observation_logger_facade(_configuration, outcome_msg_sender, _watchdog, observation_time_provider, &_error_cb));
+    _outcome_logger.reset(new logger::observation_logger_facade(_configuration, outcome_msg_sender, _watchdog, observation_time_provider, nullptr, &_error_cb));
     RETURN_IF_FAIL(_outcome_logger->init(status));
 
     return error_code::success;

--- a/rlclientlib/logger/async_batcher.h
+++ b/rlclientlib/logger/async_batcher.h
@@ -20,17 +20,30 @@ namespace reinforcement_learning {
 
 namespace reinforcement_learning { namespace logger {
 
+  template<typename TEvent>
+  class i_async_batcher {
+  public:
+    virtual ~i_async_batcher() {}
+
+    virtual int init(api_status* status) = 0;
+
+    virtual int append(TEvent&& evt, api_status* status = nullptr) = 0;
+    virtual int append(TEvent& evt, api_status* status = nullptr) = 0;
+
+    virtual int run_iteration(api_status* status) = 0;
+  };
+
   // This class takes uses a queue and a background thread to accumulate events, and send them by batch asynchronously.
   // A batch is shipped with TSender::send(data)
   template<typename TEvent, template<typename> class TSerializer = json_collection_serializer>
-  class async_batcher {
+  class async_batcher: public i_async_batcher<TEvent> {
   public:
-    int init(api_status* status);
+    int init(api_status* status) override;
 
-    int append(TEvent&& evt, api_status* status = nullptr);
-    int append(TEvent& evt, api_status* status = nullptr);
+    int append(TEvent&& evt, api_status* status = nullptr) override;
+    int append(TEvent& evt, api_status* status = nullptr) override;
 
-    int run_iteration(api_status* status);
+    int run_iteration(api_status* status) override;
 
   private:
     int fill_buffer(std::shared_ptr<utility::data_buffer>& retbuffer,

--- a/rlclientlib/logger/event_logger.cc
+++ b/rlclientlib/logger/event_logger.cc
@@ -27,6 +27,10 @@ namespace reinforcement_learning { namespace logger {
 
   int generic_event_logger::log(const char* event_id, generic_event::payload_buffer_t&& payload, generic_event::payload_type_t type, api_status* status) {
     const auto now = _time_provider != nullptr ? _time_provider->gmt_now() : timestamp();
+    if(_payload_transformer.get() != nullptr)
+    {
+      RETURN_IF_FAIL(_payload_transformer->transform(payload, status));
+    }
     return append(generic_event(event_id, now, type, std::move(payload)), status);
   }
 }}

--- a/rlclientlib/logger/logger_facade.cc
+++ b/rlclientlib/logger/logger_facade.cc
@@ -11,24 +11,35 @@ namespace reinforcement_learning {
       RETURN_ERROR_ARG(nullptr, status, protocol_not_supported, "Current protocol version is not supported");
     }
 
+
+    template<typename T>
+    i_async_batcher<T>* create_async_batcher(const utility::configuration& c, i_message_sender* sender, utility::watchdog& watchdog, error_callback_fn* perror_cb, const char *section) {
+      auto config = utility::get_batcher_config(c, section);
+      return new async_batcher<T, fb_collection_serializer>(
+        sender,
+        watchdog,
+        perror_cb,
+        config
+      );
+    }
+
     interaction_logger_facade::interaction_logger_facade(
       model_type_t model_type,
       const utility::configuration& c,
       i_message_sender* sender,
       utility::watchdog& watchdog,
       i_time_provider* time_provider,
+      i_payload_transformer* transformer,
       error_callback_fn* perror_cb)
     : _model_type(model_type)
     , _version(c.get_int(name::PROTOCOL_VERSION, value::DEFAULT_PROTOCOL_VERSION))
-    , _v1_cb(_version == 1 && _model_type == model_type_t::CB ? new interaction_logger(c, sender, watchdog, time_provider, perror_cb) : nullptr)
-    , _v1_ccb(_version == 1 && _model_type == model_type_t::CCB ? new ccb_logger(c, sender, watchdog, time_provider, perror_cb) : nullptr)
-    , _v1_multislot(_version == 1 && _model_type == model_type_t::SLATES ? new multi_slot_logger(c, sender, watchdog, time_provider, perror_cb) : nullptr)
+    , _v1_cb(_version == 1 && _model_type == model_type_t::CB ? new interaction_logger(time_provider, create_async_batcher<ranking_event>(c, sender, watchdog, perror_cb, INTERACTION_SECTION)) : nullptr)
+    , _v1_ccb(_version == 1 && _model_type == model_type_t::CCB ? new ccb_logger(time_provider, create_async_batcher<decision_ranking_event>(c, sender, watchdog, perror_cb, INTERACTION_SECTION)) : nullptr)
+    , _v1_multislot(_version == 1 && _model_type == model_type_t::SLATES ? new multi_slot_logger(time_provider, create_async_batcher<multi_slot_decision_event>(c, sender, watchdog, perror_cb, INTERACTION_SECTION)) : nullptr)
     , _v2(_version == 2 ? new generic_event_logger(
-      sender,
-      utility::get_batcher_config(c, INTERACTION_SECTION),
-      watchdog,
       time_provider,
-      perror_cb) : nullptr) {
+      create_async_batcher<generic_event>(c, sender, watchdog, perror_cb, INTERACTION_SECTION),
+      transformer) : nullptr) {
     }
 
     int interaction_logger_facade::init(api_status* status) {
@@ -103,15 +114,19 @@ namespace reinforcement_learning {
       }
     }
 
-    observation_logger_facade::observation_logger_facade(const utility::configuration& c, i_message_sender* sender, utility::watchdog& watchdog, i_time_provider* time_provider, error_callback_fn* perror_cb)
+    observation_logger_facade::observation_logger_facade(
+      const utility::configuration& c,
+      i_message_sender* sender,
+      utility::watchdog& watchdog,
+      i_time_provider* time_provider,
+      i_payload_transformer* transformer,
+      error_callback_fn* perror_cb)
     : _version(c.get_int(name::PROTOCOL_VERSION, value::DEFAULT_PROTOCOL_VERSION))
-    , _v1(_version == 1 ? new observation_logger(c, sender, watchdog, time_provider, perror_cb) : nullptr)
+    , _v1(_version == 1 ? new observation_logger(time_provider, create_async_batcher<outcome_event>(c, sender, watchdog, perror_cb, OBSERVATION_SECTION)) : nullptr)
     , _v2(_version == 2 ? new generic_event_logger(
-      sender,
-      utility::get_batcher_config(c, OBSERVATION_SECTION),
-      watchdog,
       time_provider,
-      perror_cb) : nullptr) {
+      create_async_batcher<generic_event>(c, sender, watchdog, perror_cb, OBSERVATION_SECTION),
+      transformer) : nullptr) {
     }
 
     int observation_logger_facade::init(api_status* status) {

--- a/rlclientlib/logger/logger_facade.h
+++ b/rlclientlib/logger/logger_facade.h
@@ -23,7 +23,7 @@ namespace reinforcement_learning
     public:
       interaction_logger_facade(reinforcement_learning::model_management::model_type_t model_type,
         const utility::configuration& c, i_message_sender* sender, utility::watchdog& watchdog,
-        i_time_provider* time_provider, error_callback_fn* perror_cb = nullptr);
+        i_time_provider* time_provider, i_payload_transformer* transformer = nullptr, error_callback_fn* perror_cb = nullptr);
       
       interaction_logger_facade(const interaction_logger_facade& other) = delete;
       interaction_logger_facade& operator=(const interaction_logger_facade& other) = delete;
@@ -65,7 +65,9 @@ namespace reinforcement_learning
 
     class observation_logger_facade {
     public:
-      observation_logger_facade(const utility::configuration& c, i_message_sender* sender, utility::watchdog& watchdog, i_time_provider* time_provider, error_callback_fn* perror_cb = nullptr);
+      observation_logger_facade(const utility::configuration& c,
+        i_message_sender* sender, utility::watchdog& watchdog, i_time_provider* time_provider,
+        i_payload_transformer* transformer, error_callback_fn* perror_cb = nullptr);
 
       observation_logger_facade(const observation_logger_facade& other) = delete;
       observation_logger_facade& operator=(const observation_logger_facade& other) = delete;

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -24,6 +24,7 @@ set(TEST_SOURCES
   str_util_test.cc
   unit_test.vcxproj.filters
   watchdog_test.cc
+  event_logger_test.cc
 )
 
 if (vw_USE_AZURE_FACTORIES)

--- a/unit_test/event_logger_test.cc
+++ b/unit_test/event_logger_test.cc
@@ -1,0 +1,59 @@
+#define BOOST_TEST_DYN_LINK
+#ifdef STAND_ALONE
+#   define BOOST_TEST_MODULE Main
+#endif
+
+#include <boost/test/unit_test.hpp>
+#include "generic_event.h"
+#include "logger/async_batcher.h"
+#include "logger/event_logger.h"
+#include "constants.h"
+#include "serialization/payload_serializer.h"
+
+namespace r = reinforcement_learning;
+namespace err = reinforcement_learning::error_code;
+namespace v = reinforcement_learning::value;
+namespace l = reinforcement_learning::logger;
+namespace fb = flatbuffers;
+
+struct my_async_batcher : public l::i_async_batcher<r::generic_event>\
+{
+    size_t _last_append_size;
+
+    ~my_async_batcher() override {}
+
+    int init(r::api_status* status) override { return err::success; }
+    int append(r::generic_event&& evt, r::api_status* status = nullptr) override {
+        return err::success;
+    }
+    int append(r::generic_event& evt, r::api_status* status = nullptr) override {
+        _last_append_size = evt.get_payload().size();
+        return err::success;
+    }
+    int run_iteration(r::api_status* status) override {
+        return err::success;
+    }
+};
+
+struct my_transformer: public l::i_payload_transformer {
+    ~my_transformer() override = default;
+    int transform(r::generic_event::payload_buffer_t &input, r::api_status* status) override
+    {
+        uint8_t* data = (uint8_t*)malloc(10);
+        input = fb::DetachedBuffer(nullptr, false, data, 0, data, 10);
+        return err::success;
+    }
+};
+
+BOOST_AUTO_TEST_CASE(generic_event_logger_with_transformer) { 
+    auto batcher = new my_async_batcher();
+    l::generic_event_logger logger(nullptr, batcher, new my_transformer());
+    BOOST_CHECK_EQUAL(err::success, logger.init(nullptr));
+
+    l::outcome_serializer ser;
+    
+    auto payload = ser.numeric_event(1);
+    BOOST_CHECK_NE(10, payload.size());
+    BOOST_CHECK_EQUAL(err::success, logger.log("evt", std::move(payload), r::generic_event::payload_type_t::PayloadType_Outcome, nullptr));
+    BOOST_CHECK_EQUAL(10, batcher->_last_append_size);
+}


### PR DESCRIPTION
The plan is to use i_async_batcher to abstract over the collection serializer used.
We'll use that to have a serializer that applies dedup.

i_payload_transformer will be used to apply compression to each event.