### PR TITLE
Fixes for warnings C4018 and C4456

### DIFF
--- a/rlclientlib/live_model_impl.cc
+++ b/rlclientlib/live_model_impl.cc
@@ -233,7 +233,7 @@ namespace reinforcement_learning {
     std::string model_version;
 
     // This will behave correctly both before a model is loaded and after. Prior to a model being loaded it operates in explore only mode.
-    RETURN_IF_FAIL(_model->request_multi_slot_decision(event_id, num_decisions, context_json, actions_ids, actions_pdfs, model_version, status));
+    RETURN_IF_FAIL(_model->request_multi_slot_decision(event_id, (uint32_t)num_decisions, context_json, actions_ids, actions_pdfs, model_version, status));
 
     RETURN_IF_FAIL(populate_multi_slot_response(actions_ids, actions_pdfs, std::string(event_id), std::string(model_version), resp, _trace_logger.get(), status));
     RETURN_IF_FAIL(_interaction_logger->log_decision(event_id, context_json, flags, actions_ids, actions_pdfs, model_version, status));

--- a/rlclientlib/utility/context_helper.cc
+++ b/rlclientlib/utility/context_helper.cc
@@ -42,11 +42,11 @@ namespace reinforcement_learning { namespace utility {
       const rj::Value::ConstMemberIterator& itr = obj.FindMember(slots);
       if (itr != obj.MemberEnd() && itr->value.IsArray()) {
         const auto& arr = itr->value.GetArray();
-        for (int i = 0; i < arr.Size(); ++i) {
+        for (rj::SizeType i = 0; i < arr.Size(); ++i) {
           const auto& current = arr[i];
-          const auto itr = current.FindMember(event_id);
-          if(itr != current.MemberEnd() && itr->value.IsString()) {
-            const auto event_id_string = std::string(itr->value.GetString());
+          const auto member_itr = current.FindMember(event_id);
+          if(member_itr != current.MemberEnd() && member_itr->value.IsString()) {
+            const auto event_id_string = std::string(member_itr->value.GetString());
             event_ids[i] = std::string{ event_id_string.begin(), event_id_string.end() };
           }
         }

--- a/rlclientlib/vw_model/safe_vw.cc
+++ b/rlclientlib/vw_model/safe_vw.cc
@@ -220,7 +220,7 @@ namespace reinforcement_learning {
 
     VW::read_line_json<false>(*_vw, examples, &line_vec[0], get_or_create_example_f, this);
     // In order to control the seed for the sampling of each slot the event id + app id is passed in as the seed using the example tag.
-    for(int i = 0; i < (int)slot_count; i++)
+    for(uint32_t i = 0; i < slot_count; i++)
     {
       const size_t slot_example_indx = examples.size() - slot_count + i;
       auto index_as_string = std::to_string(i);

--- a/rlclientlib/vw_model/safe_vw.cc
+++ b/rlclientlib/vw_model/safe_vw.cc
@@ -220,7 +220,7 @@ namespace reinforcement_learning {
 
     VW::read_line_json<false>(*_vw, examples, &line_vec[0], get_or_create_example_f, this);
     // In order to control the seed for the sampling of each slot the event id + app id is passed in as the seed using the example tag.
-    for(int i = 0; i < slot_count; i++)
+    for(int i = 0; i < (int)slot_count; i++)
     {
       const size_t slot_example_indx = examples.size() - slot_count + i;
       auto index_as_string = std::to_string(i);


### PR DESCRIPTION
C4018: `live_model_impl.cc` and `safe_vw` have some implicit casts from `size_t`. Explicit casting bypasses warning C4018
C4456: The variable `itr` in `context_helper.cc` is declared twice in a nested loop