### PR TITLE
Fix unit tests when run standalone

### DIFF
--- a/unit_test/live_model_test.cc
+++ b/unit_test/live_model_test.cc
@@ -414,7 +414,7 @@ BOOST_AUTO_TEST_CASE(live_model_outcome) {
   config.set(r::name::EH_TEST, "true");
 
   //create a ds live_model, and initialize with configuration
-  r::live_model ds = create_mock_live_model(config);
+  r::live_model ds = create_mock_live_model(config, nullptr, nullptr, nullptr, r::model_management::model_type_t::CB);
 
   //check api_status content when errors are returned
   r::api_status status;
@@ -459,7 +459,7 @@ BOOST_AUTO_TEST_CASE(live_model_outcome_with_secondary_id_and_v1) {
   config.set(r::name::EH_TEST, "true");
 
   //create a ds live_model, and initialize with configuration
-  r::live_model ds = create_mock_live_model(config);
+  r::live_model ds = create_mock_live_model(config, nullptr, nullptr, nullptr, r::model_management::model_type_t::CB);
 
   //check api_status content when errors are returned
   r::api_status status;
@@ -485,7 +485,7 @@ BOOST_AUTO_TEST_CASE(live_model_outcome_with_secondary_id_and_v2) {
   config.set(r::name::PROTOCOL_VERSION, "2");
 
   //create a ds live_model, and initialize with configuration
-  r::live_model ds = create_mock_live_model(config);
+  r::live_model ds = create_mock_live_model(config, nullptr, nullptr, nullptr, r::model_management::model_type_t::CB);
 
   //check api_status content when errors are returned
   r::api_status status;
@@ -608,7 +608,7 @@ BOOST_AUTO_TEST_CASE(live_model_background_refresh) {
 
     config.set(r::name::EH_TEST, "true");
 
-    r::live_model model = create_mock_live_model(config);
+    r::live_model model = create_mock_live_model(config, nullptr, nullptr, nullptr, r::model_management::model_type_t::CB);
 
     r::api_status status;
     BOOST_CHECK_EQUAL(model.init(&status), err::success);
@@ -622,7 +622,7 @@ BOOST_AUTO_TEST_CASE(live_model_no_background_refresh) {
     config.set(r::name::EH_TEST, "true");
     config.set(r::name::MODEL_BACKGROUND_REFRESH, "false");
 
-    r::live_model model = create_mock_live_model(config);
+    r::live_model model = create_mock_live_model(config, nullptr, nullptr, nullptr, r::model_management::model_type_t::CB);
 
     r::api_status status;
     BOOST_CHECK_EQUAL(model.init(&status), err::success);


### PR DESCRIPTION
Some tests don't define model type when creating the mock model, which works fine when they are run all together (it looks like fakeit is storing some vars between runs) but when run standalone these tests will fail.