### PR TITLE
Write out full namespace for target of operator<< overload

### DIFF
--- a/include/configuration.h
+++ b/include/configuration.h
@@ -45,7 +45,7 @@ namespace reinforcement_learning { namespace utility {
     //! Gets the value as a float.  If the value does not exist or if there is an error, it returns defval
     float get_float(const char* name, float defval) const; 
     //! friend Left shift operator
-    friend std::ostream& ::operator<<(std::ostream& os, const configuration&);
+    friend std::ostream& ::operator<<(std::ostream& os, const reinforcement_learning::utility::configuration&);
 
   private:
     using map_type = std::unordered_map<std::string, std::string>;  //! Collection type that holds the (name,value) pairs 


### PR DESCRIPTION
To prevent conflicts with other classes that share the name `configuration`, this change ensures the friend `operator<<` of the `configuration` class references the correct one.

**Example errors**

```c++
<root>\reinforcement_learning\include\Configuration.h(48,76): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
<root>\reinforcement_learning\include\Configuration.h(48,76): error C4430:     friend std::ostream& ::operator<<(std::ostream& os, const configuration&);
<root>\reinforcement_learning\include\Configuration.h(48,76): error C4430:                                                                            ^ 
<root>\reinforcement_learning\include\Configuration.h(48,76): error C2143: syntax error: missing ',' before '&' 
<root>\reinforcement_learning\include\Configuration.h(48,76): error C2143:     friend std::ostream& ::operator<<(std::ostream& os, const configuration&); 
<root>\reinforcement_learning\include\Configuration.h(48,76): error C2143:                                                                            ^ 
<root>\reinforcement_learning\include\Configuration.h(48,78): error C2063: 'operator <<': not a function 
<root>\reinforcement_learning\include\Configuration.h(48,78): error C2063:     friend std::ostream& ::operator<<(std::ostream& os, const configuration&); 
<root>\reinforcement_learning\include\Configuration.h(48,78): error C2063:                                                                              ^ 
```