### PR TITLE
Update dedup.cc

### DIFF
--- a/rlclientlib/dedup.cc
+++ b/rlclientlib/dedup.cc
@@ -283,7 +283,7 @@ public:
 	logger::i_async_batcher<generic_event>* create_batcher(logger::i_message_sender* sender, utility::watchdog& watchdog,
 																									error_callback_fn* perror_cb, const char* section) override {
 		auto config = utility::get_batcher_config(_config, section);
-		int _dummy = 0;
+
     if(_use_dedup) {
       return new logger::async_batcher<generic_event, dedup_collection_serializer>(
           sender,


### PR DESCRIPTION
D:\src\qas\private\answers\SDS\QCS\lib\src\RLClient\reinforcement_learning\rlclientlib\dedup.cc(295,1): warning C4456: declaration of '_dummy' hides previous local declaration [D:\src\qas\private\answers\SDS\QCS\lib\src\RLClient\src\r
lclientlib.vcxproj]
D:\src\qas\private\answers\SDS\QCS\lib\src\RLClient\reinforcement_learning\rlclientlib\dedup.cc(295,1): warning C4456:       int _dummy = 0; [D:\src\qas\private\answers\SDS\QCS\lib\src\RLClient\src\rlclientlib.vcxproj]
D:\src\qas\private\answers\SDS\QCS\lib\src\RLClient\reinforcement_learning\rlclientlib\dedup.cc(295,1): warning C4456: ^ [D:\src\qas\private\answers\SDS\QCS\lib\src\RLClient\src\rlclientlib.vcxproj]
D:\src\qas\private\answers\SDS\QCS\lib\src\RLClient\reinforcement_learning\rlclientlib\dedup.cc(286,7): message : see declaration of '_dummy' [D:\src\qas\private\answers\SDS\QCS\lib\src\RLClient\src\rlclientlib.vcxproj]
D:\src\qas\private\answers\SDS\QCS\lib\src\RLClient\reinforcement_learning\rlclientlib\dedup.cc(286,7): message :               int _dummy = 0; [D:\src\qas\private\answers\SDS\QCS\lib\src\RLClient\src\rlclientlib.vcxproj]
D:\src\qas\private\answers\SDS\QCS\lib\src\RLClient\reinforcement_learning\rlclientlib\dedup.cc(286,7): message :                   ^ [D:\src\qas\private\answers\SDS\QCS\lib\src\RLClient\src\rlclientlib.vcxproj]
D