### PR TITLE
Fix a bunch of issues found by VS 2019 compiled and  /permissive-

### DIFF
--- a/include/container_iterator.h
+++ b/include/container_iterator.h
@@ -48,7 +48,7 @@ namespace reinforcement_learning {
     TElem& operator*() {
       return _coll[_idx];
     }
-    const TElem& operator*() const {
+    TElem& operator*() const {
       return _coll[_idx];
     }
 
@@ -58,40 +58,41 @@ namespace reinforcement_learning {
     }
 
     //! Allow comparison of iterators
-    bool operator<=(const container_iterator &rhs) const {
+    bool operator<=(const container_iterator& rhs) const {
       return _idx <= rhs._idx;
     }
 
     //! Allow comparison of iterators
-    bool operator>(const container_iterator &rhs) const {
+    bool operator>(const container_iterator& rhs) const {
       return _idx > rhs._idx;
     }
 
     //! Allow comparison of iterators
-    bool operator>=(const container_iterator &rhs) const {
+    bool operator>=(const container_iterator& rhs) const {
       return _idx >= rhs._idx;
     }
     //! Allow distance measurement
-    int64_t operator-(const container_iterator& rhs) const {
-      return static_cast<int64_t>(_idx) - static_cast<int64_t>(rhs._idx);
+    size_t operator-(const container_iterator& rhs) const {
+      return static_cast<size_t>(_idx) - static_cast<size_t>(rhs._idx);
     }
+
     //! Allow distance measurement
-    container_iterator operator-(const int idx) const {
+    container_iterator operator-(const size_t idx) const {
       return { _coll, _idx - idx };
     }
+
     //! Increment the index
-    container_iterator operator+(const int idx) const {
+    container_iterator operator+(const size_t idx) const {
       return { _coll, _idx + idx };
     }
 
     //! add and assign the index
-    container_iterator& operator+=(const int idx) {
+    container_iterator & operator+=(const size_t idx) {
       this->_idx += idx;
       return *this;
     }
-    
     //! subtract and assign operator
-    container_iterator& operator-=(const int idx) {
+    container_iterator& operator-=(const size_t idx) {
       this->_idx -= idx;
       return *this;
     }
@@ -113,7 +114,7 @@ namespace reinforcement_learning {
   */
   template<typename TElem, typename TColl = std::vector<TElem>>
   class const_container_iterator : public std::iterator<
-    std::forward_iterator_tag,
+    std::random_access_iterator_tag,
     TElem> {
   public:
     //! Construct an iterator using container implementation
@@ -145,6 +146,7 @@ namespace reinforcement_learning {
     bool operator<(const const_container_iterator& rhs) const {
       return _idx < rhs._idx;
     }
+
     //! Allow distance measurement
     int64_t operator-(const const_container_iterator& rhs) const {
       return _idx - rhs._idx;

--- a/include/multi_slot_response.h
+++ b/include/multi_slot_response.h
@@ -25,11 +25,11 @@ namespace reinforcement_learning {
     void set_probability(float prob);
   private:
     //! slot entry id
-    std::string id;
+    std::string _id;
     //! action id
-    uint32_t action_id;
+    uint32_t _action_id;
     //! probability associated with the action id
-    float probability;
+    float _probability;
   };
 
   /**

--- a/rlclientlib/live_model_impl.cc
+++ b/rlclientlib/live_model_impl.cc
@@ -609,7 +609,7 @@ namespace reinforcement_learning {
 
   int reset_chosen_action_multi_slot(multi_slot_response& response, const std::vector<int>& baseline_actions)
   {
-    size_t index = 0;
+    uint32_t index = 0;
     for (auto &slot : response)
     {
       if (!baseline_actions.empty() && baseline_actions.size() >= index)

--- a/rlclientlib/multi_slot_response.cc
+++ b/rlclientlib/multi_slot_response.cc
@@ -4,30 +4,30 @@
 
 namespace reinforcement_learning
 {
-  slot_entry::slot_entry(const std::string& _id, uint32_t _action_id, float _probability)
-    : id(_id)
-    , action_id(_action_id)
-    , probability(_probability) {
+  slot_entry::slot_entry(const std::string& id, uint32_t action_id, float probability)
+    : _id(id)
+    , _action_id(action_id)
+    , _probability(probability) {
   }
 
   const char* slot_entry::get_id() const {
-    return id.c_str();
+    return _id.c_str();
   }
 
   uint32_t slot_entry::get_action_id() const {
-    return action_id;
+    return _action_id;
   }
 
-  void slot_entry::set_action_id(uint32_t id) {
-    action_id = id;
+  void slot_entry::set_action_id(uint32_t action_id) {
+    _action_id = action_id;
   }
 
   void slot_entry::set_probability(float prob) {
-    probability = prob;
+    _probability = prob;
   }
 
   float slot_entry::get_probability() const {
-    return probability;
+    return _probability;
   }
 
   void multi_slot_response::set_event_id(const char* event_id) {

--- a/rlclientlib/multi_slot_response_detailed.cc
+++ b/rlclientlib/multi_slot_response_detailed.cc
@@ -36,6 +36,7 @@ namespace reinforcement_learning
       RETURN_ERROR_ARG(nullptr, status, slot_index_out_of_bounds_error, "Slot index out of bounds");
     }
     _decision[index] = std::move(slot);
+    return error_code::success;
   }
 
   void multi_slot_response_detailed::clear() {


### PR DESCRIPTION
In particular:

Make sure `container_iterator` and `const_container_iterator` correctly
work as random access iterators.

Fix `container_iterator::operator*()const` to return a non-const value.
A const interator is not the same thing as a const_interator. C++
constness is a constant source of joyfull surprises.

Beyond that, fix a couple variable size issues and a missing return code
in a falible function.