### PR TITLE
Fix a bunch of bugs plus an improvement to log_parser that I used to debug this.

### DIFF
--- a/bindings/cs/rl.net.cli/PerfTestCommand.cs
+++ b/bindings/cs/rl.net.cli/PerfTestCommand.cs
@@ -73,11 +73,12 @@ namespace Rl.Net.Cli
             };
 
             Console.WriteLine(stepProvider.DataSize);
-            RLDriver rlDriver = new RLDriver(liveModel, loopKind: this.GetLoopKind())
+            using (RLDriver rlDriver = new RLDriver(liveModel, loopKind: this.GetLoopKind()))
             {
-                StepInterval = TimeSpan.FromMilliseconds(this.SleepIntervalMs)
-            };
-            rlDriver.Run(stepProvider);
+                rlDriver.StepInterval = TimeSpan.FromMilliseconds(this.SleepIntervalMs);
+                rlDriver.Run(stepProvider);
+            }
+
             stepProvider.Stats.Print();
             return stepProvider;
         }

--- a/bindings/cs/rl.net.cli/RLDriver.cs
+++ b/bindings/cs/rl.net.cli/RLDriver.cs
@@ -85,7 +85,7 @@ namespace Rl.Net.Cli
         bool TryQueueOutcomeEvent(RunContext runContext, string eventId, string slotId, TOutcome outcome);
     }
 
-    public class RLDriver : IOutcomeReporter<float>, IOutcomeReporter<string>
+    public class RLDriver : IOutcomeReporter<float>, IOutcomeReporter<string>, IDisposable
     {
         private LiveModel liveModel;
         private LoopKind loopKind;
@@ -250,5 +250,30 @@ namespace Rl.Net.Cli
                 localHandler(this, errorStatus);
             }
         }
+
+        #region IDisposable Support
+        private bool disposedValue = false; // To detect redundant calls
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    this.liveModel?.Dispose();
+                    this.liveModel = null;
+                }
+
+                disposedValue = true;
+            }
+        }
+
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+        }
+        #endregion
     }
 }

--- a/bindings/cs/rl.net.cli/RLSimulator.cs
+++ b/bindings/cs/rl.net.cli/RLSimulator.cs
@@ -283,7 +283,7 @@ namespace Rl.Net.Cli
         }
     }
 
-    internal class RLSimulator
+    internal class RLSimulator : IDisposable
     {
         private RLDriver driver;
 
@@ -322,5 +322,29 @@ namespace Rl.Net.Cli
                 this.driver.OnError -= value;
             }
         }
+
+        #region IDisposable Support
+        private bool disposedValue = false; // To detect redundant calls
+
+        protected virtual void Dispose(bool disposing)
+        {
+            Console.WriteLine("Disponsing rlsim");
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    this.driver?.Dispose();
+                    this.driver = null;
+                }
+
+                disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+        #endregion
     }
 }

--- a/bindings/cs/rl.net.cli/ReplayCommand.cs
+++ b/bindings/cs/rl.net.cli/ReplayCommand.cs
@@ -17,15 +17,17 @@ namespace Rl.Net.Cli
         public override void Run()
         {
             LiveModel liveModel = Helpers.CreateLiveModelOrExit(this.ConfigPath);
-            RLDriver rlDriver = new RLDriver(liveModel, loopKind: this.GetLoopKind());
-            rlDriver.StepInterval = TimeSpan.FromMilliseconds(this.SleepIntervalMs);
-
-            using (TextReader textReader = File.OpenText(this.LogPath))
+            using (RLDriver rlDriver = new RLDriver(liveModel, loopKind: this.GetLoopKind()))
             {
-                IEnumerable<string> dsJsonLines = textReader.LazyReadLines();
-                ReplayStepProvider stepProvider = new ReplayStepProvider(dsJsonLines);
+                rlDriver.StepInterval = TimeSpan.FromMilliseconds(this.SleepIntervalMs);
 
-                rlDriver.Run(stepProvider);
+                using (TextReader textReader = File.OpenText(this.LogPath))
+                {
+                    IEnumerable<string> dsJsonLines = textReader.LazyReadLines();
+                    ReplayStepProvider stepProvider = new ReplayStepProvider(dsJsonLines);
+
+                    rlDriver.Run(stepProvider);
+                }
             }
         }
     }

--- a/bindings/cs/rl.net.cli/RunSimulatorCommand.cs
+++ b/bindings/cs/rl.net.cli/RunSimulatorCommand.cs
@@ -16,10 +16,12 @@ namespace Rl.Net.Cli
         {
             LiveModel liveModel = Helpers.CreateLiveModelOrExit(this.ConfigPath);
 
-            RLSimulator rlSim = new RLSimulator(liveModel, loopKind: this.GetLoopKind());
-            rlSim.StepInterval = TimeSpan.FromMilliseconds(this.SleepIntervalMs);
-            rlSim.OnError += (sender, apiStatus) => Helpers.WriteStatusAndExit(apiStatus);
-            rlSim.Run(this.Steps);
+            using (RLSimulator rlSim = new RLSimulator(liveModel, loopKind: this.GetLoopKind()))
+            {
+                rlSim.StepInterval = TimeSpan.FromMilliseconds(this.SleepIntervalMs);
+                rlSim.OnError += (sender, apiStatus) => Helpers.WriteStatusAndExit(apiStatus);
+                rlSim.Run(this.Steps);
+            }
         }
     }
 }

--- a/bindings/cs/rl.net.native/binding_tracer.cc
+++ b/bindings/cs/rl.net.native/binding_tracer.cc
@@ -6,6 +6,8 @@ namespace rl_net_native {
   : context(_context) {
   }
 
+  binding_tracer::~binding_tracer() { }
+
   void binding_tracer::log(int log_level, const std::string& msg) {
     if (context.trace_logger_callback != nullptr) {
       context.trace_logger_callback(log_level, msg.c_str());

--- a/bindings/cs/rl.net.native/binding_tracer.h
+++ b/bindings/cs/rl.net.native/binding_tracer.h
@@ -8,6 +8,7 @@ namespace rl_net_native {
     // Inherited via i_trace
     binding_tracer(livemodel_context& _context);
     void log(int log_level, const std::string &msg) override;
+	virtual ~binding_tracer();
   private:
     livemodel_context& context;
   };

--- a/rlclientlib/dedup.cc
+++ b/rlclientlib/dedup.cc
@@ -281,7 +281,7 @@ public:
     logger::i_logger_extensions(c), _dedup_state(c, use_compression, use_dedup, time_provider), _use_dedup(use_dedup), _use_compression(use_compression) {}
 
 	logger::i_async_batcher<generic_event>* create_batcher(logger::i_message_sender* sender, utility::watchdog& watchdog,
-																									error_callback_fn* perror_cb, const char* section) override {
+																									error_callback_fn* perror_cb, i_trace* trace, const char* section) override {
 		auto config = utility::get_batcher_config(_config, section);
 
     if(_use_dedup) {
@@ -290,6 +290,7 @@ public:
           watchdog,
           _dedup_state,
           perror_cb,
+		  trace,
           config);
     } else {
       int _dummy = 0;
@@ -298,6 +299,7 @@ public:
           watchdog,
           _dummy,
           perror_cb,
+		  trace,
           config);
     }
 

--- a/rlclientlib/live_model_impl.h
+++ b/rlclientlib/live_model_impl.h
@@ -59,6 +59,7 @@ namespace reinforcement_learning
       model_factory_t* m_factory,
       sender_factory_t* sender_factory,
       time_provider_factory_t* time_provider_factory);
+	~live_model_impl();
 
     live_model_impl(const live_model_impl&) = delete;
     live_model_impl(live_model_impl&&) = delete;

--- a/rlclientlib/logger/event_logger.h
+++ b/rlclientlib/logger/event_logger.h
@@ -29,6 +29,8 @@ namespace reinforcement_learning { namespace logger {
 
     int init(api_status* status);
 
+	void flush();
+
   protected:
     int append(TEvent&& item, api_status* status);
     int append(TEvent& item, api_status* status);
@@ -53,6 +55,13 @@ namespace reinforcement_learning { namespace logger {
     RETURN_IF_FAIL(_batcher->init(status));
     _initialized = true;
     return error_code::success;
+  }
+
+
+  template<typename TEvent>
+  void event_logger<TEvent>::flush()
+  {
+	  _batcher->flush();
   }
 
   template<typename TEvent>

--- a/rlclientlib/logger/logger_extensions.cc
+++ b/rlclientlib/logger/logger_extensions.cc
@@ -10,7 +10,7 @@ public:
 		delete provider; //We don't use it
 	}
 
-	i_async_batcher<generic_event>* create_batcher(i_message_sender* sender, utility::watchdog& watchdog, error_callback_fn* perror_cb, const char* section) override {
+	i_async_batcher<generic_event>* create_batcher(i_message_sender* sender, utility::watchdog& watchdog, error_callback_fn* perror_cb, i_trace* trace, const char* section) override {
 		auto config = utility::get_batcher_config(_config, section);
 		int _dummy = 0;
 		return new async_batcher<generic_event, fb_collection_serializer>(
@@ -18,6 +18,7 @@ public:
 				watchdog,
 				_dummy,
 				perror_cb,
+			    trace,
 				config);
 	}
 

--- a/rlclientlib/logger/logger_facade.cc
+++ b/rlclientlib/logger/logger_facade.cc
@@ -13,7 +13,7 @@ namespace reinforcement_learning {
 
     template<typename T>
     i_async_batcher<T>* create_legacy_async_batcher(const utility::configuration& c, i_message_sender* sender, utility::watchdog& watchdog,
-      error_callback_fn* perror_cb, const char *section, typename async_batcher<T, fb_collection_serializer>::shared_state_t &shared_state) {
+      error_callback_fn* perror_cb, i_trace *trace, const char *section, typename async_batcher<T, fb_collection_serializer>::shared_state_t &shared_state) {
 
       auto config = utility::get_batcher_config(c, section);
       return new async_batcher<T, fb_collection_serializer>(
@@ -21,6 +21,7 @@ namespace reinforcement_learning {
         watchdog,
         shared_state,
         perror_cb,
+		trace,
         config
       );
     }
@@ -32,17 +33,18 @@ namespace reinforcement_learning {
       utility::watchdog& watchdog,
       i_time_provider* time_provider,
       i_logger_extensions& ext,
+	  i_trace* trace,
       error_callback_fn* perror_cb)
     : _model_type(model_type)
     , _version(c.get_int(name::PROTOCOL_VERSION, value::DEFAULT_PROTOCOL_VERSION))
     , _serializer_shared_state(0)
     , _ext(ext)
-    , _v1_cb(_version == 1 && _model_type == model_type_t::CB ? new interaction_logger(time_provider, create_legacy_async_batcher<ranking_event>(c, sender, watchdog, perror_cb, INTERACTION_SECTION, _serializer_shared_state)) : nullptr)
-    , _v1_ccb(_version == 1 && _model_type == model_type_t::CCB ? new ccb_logger(time_provider, create_legacy_async_batcher<decision_ranking_event>(c, sender, watchdog, perror_cb, INTERACTION_SECTION, _serializer_shared_state)) : nullptr)
-    , _v1_multislot(_version == 1 && _model_type == model_type_t::SLATES ? new multi_slot_logger(time_provider, create_legacy_async_batcher<multi_slot_decision_event>(c, sender, watchdog, perror_cb, INTERACTION_SECTION, _serializer_shared_state)) : nullptr)
+    , _v1_cb(_version == 1 && _model_type == model_type_t::CB ? new interaction_logger(time_provider, create_legacy_async_batcher<ranking_event>(c, sender, watchdog, perror_cb, trace, INTERACTION_SECTION, _serializer_shared_state)) : nullptr)
+    , _v1_ccb(_version == 1 && _model_type == model_type_t::CCB ? new ccb_logger(time_provider, create_legacy_async_batcher<decision_ranking_event>(c, sender, watchdog, perror_cb, trace, INTERACTION_SECTION, _serializer_shared_state)) : nullptr)
+    , _v1_multislot(_version == 1 && _model_type == model_type_t::SLATES ? new multi_slot_logger(time_provider, create_legacy_async_batcher<multi_slot_decision_event>(c, sender, watchdog, perror_cb, trace, INTERACTION_SECTION, _serializer_shared_state)) : nullptr)
     , _v2(_version == 2 ? new generic_event_logger(
       time_provider,
-      ext.create_batcher(sender, watchdog, perror_cb, INTERACTION_SECTION)) : nullptr) {
+      ext.create_batcher(sender, watchdog, perror_cb, trace, INTERACTION_SECTION)) : nullptr) {
     }
 
     int interaction_logger_facade::init(api_status* status) {
@@ -158,18 +160,34 @@ namespace reinforcement_learning {
       }
     }
 
+	void interaction_logger_facade::flush() {
+		switch (_version) {
+		case 1: 
+		  if(_v1_cb)
+			_v1_cb->flush();
+		  else if (_v1_ccb)
+			  _v1_ccb->flush();
+		  else if (_v1_multislot)
+			  _v1_multislot->flush();
+		  break;
+		case 2: _v2->flush(); break;
+		}
+	}
+
+
     observation_logger_facade::observation_logger_facade(
       const utility::configuration& c,
       i_message_sender* sender,
       utility::watchdog& watchdog,
       i_time_provider* time_provider,
+	  i_trace* trace,
       error_callback_fn* perror_cb)
     : _version(c.get_int(name::PROTOCOL_VERSION, value::DEFAULT_PROTOCOL_VERSION))
     , _serializer_shared_state(0)
-    , _v1(_version == 1 ? new observation_logger(time_provider, create_legacy_async_batcher<outcome_event>(c, sender, watchdog, perror_cb, OBSERVATION_SECTION, _serializer_shared_state)) : nullptr)
+    , _v1(_version == 1 ? new observation_logger(time_provider, create_legacy_async_batcher<outcome_event>(c, sender, watchdog, perror_cb, trace, OBSERVATION_SECTION, _serializer_shared_state)) : nullptr)
     , _v2(_version == 2 ? new generic_event_logger(
       time_provider,
-      create_legacy_async_batcher<generic_event>(c, sender, watchdog, perror_cb, OBSERVATION_SECTION, _serializer_shared_state)) : nullptr) {
+      create_legacy_async_batcher<generic_event>(c, sender, watchdog, perror_cb, trace, OBSERVATION_SECTION, _serializer_shared_state)) : nullptr) {
     }
 
     int observation_logger_facade::init(api_status* status) {
@@ -232,5 +250,12 @@ namespace reinforcement_learning {
         default: return protocol_not_supported(status);
       }
     }
+
+	void observation_logger_facade::flush() {
+		switch (_version) {
+		case 1: _v1->flush(); break;
+		case 2: _v2->flush(); break;
+	  }
+	}
   }
 }

--- a/rlclientlib/logger/logger_facade.h
+++ b/rlclientlib/logger/logger_facade.h
@@ -14,6 +14,8 @@
 #include "event_logger.h"
 #include "model_mgmt.h"
 
+#include "trace_logger.h"
+
 #include "serialization/payload_serializer.h"
 
 namespace reinforcement_learning
@@ -30,7 +32,7 @@ namespace reinforcement_learning
       virtual bool is_object_extraction_enabled() const = 0;
       virtual bool is_serialization_transform_enabled() const = 0;
 
-      virtual i_async_batcher<generic_event>* create_batcher(i_message_sender* sender, utility::watchdog& watchdog, error_callback_fn* perror_cb, const char* section) = 0;
+      virtual i_async_batcher<generic_event>* create_batcher(i_message_sender* sender, utility::watchdog& watchdog, error_callback_fn* perror_cb, i_trace* trace, const char* section) = 0;
       virtual int transform_payload_and_extract_objects(const char* context, std::string& edited_payload, generic_event::object_list_t& objects, api_status* status) = 0;
       virtual int transform_serialized_payload(generic_event::payload_buffer_t& input, event_content_type &content_type, api_status* status) const = 0;
 
@@ -41,7 +43,7 @@ namespace reinforcement_learning
     public:
       interaction_logger_facade(reinforcement_learning::model_management::model_type_t model_type,
         const utility::configuration& c, i_message_sender* sender, utility::watchdog& watchdog,
-        i_time_provider* time_provider, i_logger_extensions& ext, error_callback_fn* perror_cb = nullptr);
+        i_time_provider* time_provider, i_logger_extensions& ext, i_trace* trace, error_callback_fn* perror_cb = nullptr);
 
       interaction_logger_facade(const interaction_logger_facade& other) = delete;
       interaction_logger_facade& operator=(const interaction_logger_facade& other) = delete;
@@ -51,6 +53,7 @@ namespace reinforcement_learning
       ~interaction_logger_facade() = default;
 
       int init(api_status* status);
+	  void flush();
 
       //CB v1/v2
       int log(const char* context, unsigned int flags, const ranking_response& response, api_status* status, learning_mode learning_mode = ONLINE);
@@ -87,7 +90,7 @@ namespace reinforcement_learning
     class observation_logger_facade {
     public:
       observation_logger_facade(const utility::configuration& c,
-        i_message_sender* sender, utility::watchdog& watchdog, i_time_provider* time_provider, error_callback_fn* perror_cb = nullptr);
+        i_message_sender* sender, utility::watchdog& watchdog, i_time_provider* time_provider, i_trace* trace, error_callback_fn* perror_cb = nullptr);
 
       observation_logger_facade(const observation_logger_facade& other) = delete;
       observation_logger_facade& operator=(const observation_logger_facade& other) = delete;
@@ -97,6 +100,8 @@ namespace reinforcement_learning
       ~observation_logger_facade() = default;
 
       int init(api_status* status);
+	  void flush();
+
 
       int log(const char* event_id, float outcome, api_status* status);
       int log(const char* event_id, const char* outcome, api_status* status);

--- a/test_tools/log_parser/parser.py
+++ b/test_tools/log_parser/parser.py
@@ -7,6 +7,9 @@ import json
 import struct
 import datetime
 
+import warnings
+warnings.filterwarnings("ignore", category=DeprecationWarning) 
+
 PREAMBLE_LENGTH = 8
 PRETTY_PRINT_JSON=False
 
@@ -145,9 +148,11 @@ def dump_event_batch(buf):
 
 
 def dump_preamble_file(file_name, buf):
-    preamble = parse_preamble(buf)
-    print(f'parsing preamble file {file_name}\n\tpreamble:{preamble}')
-    dump_event_batch(buf[PREAMBLE_LENGTH : PREAMBLE_LENGTH + preamble["msg_size"]])
+    while len(buf) > 8:
+        preamble = parse_preamble(buf)
+        print(f'parsing preamble file {file_name}\n\tpreamble:{preamble}')
+        dump_event_batch(buf[PREAMBLE_LENGTH : PREAMBLE_LENGTH + preamble["msg_size"]])
+        buf = buf[PREAMBLE_LENGTH + preamble["msg_size"]:]
 
 MSG_TYPE_HEADER = 0x55555555
 MSG_TYPE_CHECKPOINT = 0x11111111

--- a/unit_test/async_batcher_test.cc
+++ b/unit_test/async_batcher_test.cc
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(flush_timeout) {
   config.send_batch_interval_ms = timeout_ms;
   config.send_queue_max_capacity = 8192;
   int dummy = 0;
-  logger::async_batcher<test_undroppable_event> batcher(s, watchdog, dummy, &error_fn, config);
+  logger::async_batcher<test_undroppable_event> batcher(s, watchdog, dummy, &error_fn, nullptr, config);
   batcher.init(nullptr); // Allow periodic_background_proc inside async_batcher to start waiting
   // on a timer before sending any events to it. Else we risk not
   // triggering the batch mechanism and might get triggered by initial
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE(flush_batches) {
   config.send_batch_interval_ms = 100000;
   int dummy = 0;
   auto batcher = new logger::async_batcher<test_undroppable_event>
-      (s, watchdog, dummy, &error_fn, config);
+      (s, watchdog, dummy, &error_fn, nullptr, config);
   batcher->init(nullptr); // Allow periodic_background_proc inside async_batcher to start waiting
   // on a timer before sending any events to it.   Else we risk not
   // triggering the batch mechanism and might get triggered by initial
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE(flush_after_deletion) {
   utility::async_batcher_config config;
   int dummy = 0;
   auto* batcher = new logger::async_batcher<test_undroppable_event>
-      (s, watchdog, dummy, nullptr, config);
+      (s, watchdog, dummy, nullptr, nullptr, config);
   batcher->init(nullptr); // Allow periodic_background_proc to start waiting
   std::this_thread::sleep_for(std::chrono::milliseconds(20));
   std::string foo("foo");
@@ -184,7 +184,7 @@ BOOST_AUTO_TEST_CASE(queue_overflow_do_not_drop_event) {
   config.send_queue_max_capacity = queue_max_size;
   config.queue_mode = queue_mode;
   int dummy = 0;
-  auto batcher = new logger::async_batcher<test_droppable_event>(s, watchdog, dummy, &error_fn, config);
+  auto batcher = new logger::async_batcher<test_droppable_event>(s, watchdog, dummy, &error_fn, nullptr, config);
   batcher->init(nullptr); // Allow periodic_background_proc to start waiting
   std::this_thread::sleep_for(std::chrono::milliseconds(20));
   int n = 10;


### PR DESCRIPTION
parser.py can will now parse all preamble messages in a file.

rl.net.cli was not disposing its live model, now it does.

Introduced some basic logging to the batching process so we can do basic monitoring without having to a debugger or adding printf statements.

The extra logging turned out to be a problem because at-exit flushing was done from async_batch dtor and accessing a bunch of dangling pointers - fun stuff!

I fixed that by moving the flushing to live_model_impl, which owns everything so its dtor can do it safely.

