### PR TITLE
[Binary parser] fix reward setting bugs

### DIFF
--- a/external_parser/example_joiner.cc
+++ b/external_parser/example_joiner.cc
@@ -234,6 +234,7 @@ void example_joiner::clear_batch_info() {
   while (!_batch_event_order.empty()) {
     _batch_event_order.pop();
   }
+  _reward = _default_reward;
 }
 
 void example_joiner::clear_vw_examples(v_array<example *> &examples) {
@@ -249,6 +250,7 @@ void example_joiner::clear_event_id_batch_info(const std::string &id) {
   _batch_grouped_events.erase(id);
   _batch_event_order.pop();
   _batch_grouped_examples.erase(id);
+  _reward = _default_reward;
 }
 
 void example_joiner::invalidate_joined_event(const std::string &id) {
@@ -530,13 +532,6 @@ bool example_joiner::process_joined(v_array<example *> &examples) {
     } else {
       _reward = _original_reward;
     }
-  } else {
-    // don't learn from this interaction
-    VW::io::logger::log_warn(
-        "Interaction with event id [{}] has no observations. Skipping...", id);
-    clear_vw_examples(examples);
-    clear_event_id_batch_info(id);
-    return false;
   }
 
   if (_binary_to_json) {
@@ -557,6 +552,4 @@ bool example_joiner::process_joined(v_array<example *> &examples) {
 }
 
 bool example_joiner::processing_batch() { return !_batch_event_order.empty(); }
-float example_joiner::get_reward() { return _reward; }
-float example_joiner::get_original_reward() { return _original_reward; }
 void example_joiner::on_new_batch() {}

--- a/external_parser/example_joiner.cc
+++ b/external_parser/example_joiner.cc
@@ -112,8 +112,7 @@ void example_joiner::set_learning_mode_config(
   _learning_mode_config = learning_mode;
 }
 
-void example_joiner::set_problem_type_config(
-    v2::ProblemType problem_type) {
+void example_joiner::set_problem_type_config(v2::ProblemType problem_type) {
   _problem_type_config = problem_type;
 }
 
@@ -196,7 +195,7 @@ bool example_joiner::process_compression(const uint8_t *data, size_t size,
 }
 
 void example_joiner::try_set_label(const joined_event &je,
-                                   v_array<example *> &examples) {
+                                   v_array<example *> &examples, float reward) {
   if (je.interaction_data.actions.empty()) {
     VW::io::logger::log_warn("missing actions for event [{}]",
                              je.interaction_data.eventId);
@@ -219,7 +218,7 @@ void example_joiner::try_set_label(const joined_event &je,
 
   int index = je.interaction_data.actions[0];
   auto action = je.interaction_data.actions[0];
-  auto cost = -1.f * _reward;
+  auto cost = -1.f * reward;
   auto probability = je.interaction_data.probabilities[0] *
                      (1.f - je.interaction_data.probabilityOfDrop);
   auto weight = 1.f - je.interaction_data.probabilityOfDrop;
@@ -234,7 +233,6 @@ void example_joiner::clear_batch_info() {
   while (!_batch_event_order.empty()) {
     _batch_event_order.pop();
   }
-  _reward = _default_reward;
 }
 
 void example_joiner::clear_vw_examples(v_array<example *> &examples) {
@@ -250,7 +248,6 @@ void example_joiner::clear_event_id_batch_info(const std::string &id) {
   _batch_grouped_events.erase(id);
   _batch_event_order.pop();
   _batch_grouped_examples.erase(id);
-  _reward = _default_reward;
 }
 
 void example_joiner::invalidate_joined_event(const std::string &id) {
@@ -478,6 +475,9 @@ bool example_joiner::process_joined(v_array<example *> &examples) {
 
   auto &id = _batch_event_order.front();
   bool multiline = false;
+  float reward = _default_reward;
+  // original reward is used to record the observed reward of apprentice mode
+  float original_reward = _default_reward;
 
   for (auto &joined_event : _batch_grouped_events[id]) {
     auto event = flatbuffers::GetRoot<v2::Event>(joined_event->event()->data());
@@ -519,7 +519,7 @@ bool example_joiner::process_joined(v_array<example *> &examples) {
   }
 
   if (je.outcome_events.size() > 0) {
-    _original_reward = _reward_calculation(je);
+    original_reward = _reward_calculation(je);
 
     if (je.interaction_metadata.payload_type == v2::PayloadType_CB &&
         je.interaction_metadata.learning_mode ==
@@ -527,18 +527,18 @@ bool example_joiner::process_joined(v_array<example *> &examples) {
       if (je.interaction_data.actions[0] == je.baseline_action) {
         // TODO: default apprenticeReward should come from config
         // setting to default reward matches current behavior for now
-        _reward = _original_reward;
+        reward = original_reward;
       }
     } else {
-      _reward = _original_reward;
+      reward = original_reward;
     }
   }
 
   if (_binary_to_json) {
-    log_converter::build_cb_json(_outfile, je, _reward, _original_reward);
+    log_converter::build_cb_json(_outfile, je, reward, original_reward);
   }
 
-  try_set_label(je, examples);
+  try_set_label(je, examples, reward);
 
   if (multiline) {
     // add an empty example to signal end-of-multiline

--- a/external_parser/example_joiner.h
+++ b/external_parser/example_joiner.h
@@ -3,8 +3,8 @@
 #include "err_constants.h"
 
 #include "example.h"
-#include "lru_dedup_cache.h"
 #include "i_joiner.h"
+#include "lru_dedup_cache.h"
 #include "v_array.h"
 
 #include <fstream>
@@ -79,7 +79,8 @@ private:
   bool process_compression(const uint8_t *data, size_t size,
                            const v2::Metadata &metadata, const T *&payload);
 
-  void try_set_label(const joined_event &je, v_array<example *> &examples);
+  void try_set_label(const joined_event &je, v_array<example *> &examples,
+                     float reward);
 
   void clear_batch_info();
   void clear_event_id_batch_info(const std::string &id);
@@ -109,9 +110,6 @@ private:
   flatbuffers::DetachedBuffer _detached_buffer;
 
   float _default_reward = 0.f;
-  float _reward = _default_reward;
-  // original reward is used to record the observed reward of apprentice mode
-  float _original_reward = _default_reward;
   reward::RewardFunctionType _reward_calculation;
 
   v2::LearningModeType _learning_mode_config = v2::LearningModeType_Online;

--- a/external_parser/example_joiner.h
+++ b/external_parser/example_joiner.h
@@ -65,9 +65,6 @@ public:
 
   void on_new_batch() override;
 
-  float get_reward();
-  float get_original_reward();
-
 private:
   bool process_dedup(const v2::Event &event, const v2::Metadata &metadata);
 

--- a/external_parser/unit_tests/test_reward_functions.cc
+++ b/external_parser/unit_tests/test_reward_functions.cc
@@ -38,7 +38,14 @@ float get_float_reward(std::string int_file_name, std::string obs_file_name, v2:
 
   joiner.process_joined(examples);
 
-  float reward = joiner.get_reward();
+  // works with CB for now
+  float reward = 0.0f;
+  for (auto *example : examples) {
+    if (example->l.cb.costs.size() > 0) {
+      // found label
+      reward = -1.0 * example->l.cb.costs[0].cost;
+    }
+  }
 
   clear_examples(examples, vw);
   VW::finish(*vw);
@@ -47,79 +54,79 @@ float get_float_reward(std::string int_file_name, std::string obs_file_name, v2:
 
 BOOST_AUTO_TEST_SUITE(reward_functions_with_cb_format_and_float_reward)
 
-  // 3 rewards in f-reward_3obs_v2.fb are: 5, 4, 3 and timestamps are in descending order added in test_common.cc
-  BOOST_AUTO_TEST_CASE(earliest) {
-    float reward = get_float_reward(
+// 3 rewards in f-reward_3obs_v2.fb are: 5, 4, 3 and timestamps are in descending order added in test_common.cc
+BOOST_AUTO_TEST_CASE(earliest) {
+  float reward = get_float_reward(
       "cb_v2.fb",
       "f-reward_3obs_v2.fb",
       v2::RewardFunctionType_Earliest
     );
 
-    BOOST_CHECK_EQUAL(reward, 3);
-  }
+  BOOST_CHECK_EQUAL(reward, 3);
+}
 
-  BOOST_AUTO_TEST_CASE(average) {
-    float reward = get_float_reward(
+BOOST_AUTO_TEST_CASE(average) {
+  float reward = get_float_reward(
       "cb_v2.fb",
       "f-reward_3obs_v2.fb",
       v2::RewardFunctionType_Average
     );
 
-    BOOST_CHECK_EQUAL(reward, (3.0 + 4 + 5) / 3);
-  }
+  BOOST_CHECK_EQUAL(reward, (3.0 + 4 + 5) / 3);
+}
 
-  BOOST_AUTO_TEST_CASE(min) {
-    float reward = get_float_reward(
+BOOST_AUTO_TEST_CASE(min) {
+  float reward = get_float_reward(
       "cb_v2.fb",
       "f-reward_3obs_v2.fb",
       v2::RewardFunctionType_Min
     );
 
-    BOOST_CHECK_EQUAL(reward, 3);
-  }
+  BOOST_CHECK_EQUAL(reward, 3);
+}
 
-  BOOST_AUTO_TEST_CASE(max) {
-    float reward = get_float_reward(
+BOOST_AUTO_TEST_CASE(max) {
+  float reward = get_float_reward(
       "cb_v2.fb",
       "f-reward_3obs_v2.fb",
       v2::RewardFunctionType_Max
     );
 
-    BOOST_CHECK_EQUAL(reward, 5);
-  }
+  BOOST_CHECK_EQUAL(reward, 5);
+}
 
-  BOOST_AUTO_TEST_CASE(median) {
-    float reward = get_float_reward(
+BOOST_AUTO_TEST_CASE(median) {
+  float reward = get_float_reward(
       "cb_v2.fb",
       "f-reward_3obs_v2.fb",
       v2::RewardFunctionType_Median
     );
 
-    BOOST_CHECK_EQUAL(reward, 4);
-  }
+  BOOST_CHECK_EQUAL(reward, 4);
+}
 
-  BOOST_AUTO_TEST_CASE(sum) {
-    float reward = get_float_reward(
+BOOST_AUTO_TEST_CASE(sum) {
+  float reward = get_float_reward(
       "cb_v2.fb",
       "f-reward_3obs_v2.fb",
       v2::RewardFunctionType_Sum
     );
 
-    BOOST_CHECK_EQUAL(reward, 3 + 4 + 5);
-  }
+  BOOST_CHECK_EQUAL(reward, 3 + 4 + 5);
+}
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(reward_functions_with_cb_format_and_appentice_mode)
-  BOOST_AUTO_TEST_CASE(apprentice_with_first_action_matching_baseline_action_returns_real_reward) {
-    // 3 rewards in f-reward_3obs_v2.fb are: 5, 4, 3
-    float reward = get_float_reward(
+BOOST_AUTO_TEST_CASE(apprentice_with_first_action_matching_baseline_action_returns_real_reward) {
+  // 3 rewards in f-reward_3obs_v2.fb are: 5, 4, 3
+  float reward = get_float_reward(
       "cb_apprentice_match_baseline_v2.fb",
       "f-reward_3obs_v2.fb",
       v2::RewardFunctionType_Sum,
       v2::LearningModeType_Apprentice
     );
-    BOOST_CHECK_EQUAL(reward, 3 + 4 + 5);
-  }
+  BOOST_CHECK_EQUAL(reward, 3 + 4 + 5);
+}
 
 // TODO: add test case for first action not matching basesline returns default reward
 BOOST_AUTO_TEST_SUITE_END()

--- a/test_tools/example_gen/example_gen.cc
+++ b/test_tools/example_gen/example_gen.cc
@@ -119,7 +119,7 @@ int take_action(r::live_model& rl, const char *event_id, int action, bool gen_ra
   switch(action) {
     case CB_ACTION: {// "cb",
       r::ranking_response response;
-      if(rl.choose_rank(event_id, JSON_SLATES_CONTEXT, response, &status))
+      if(rl.choose_rank(event_id, JSON_CB_CONTEXT, response, &status))
           std::cout << status.get_error_msg() << std::endl;
       break;
     }


### PR DESCRIPTION
- reward and original_reward not member functions so that they can be reset every time
- remove skip event if observations are missing (just use default reward)
- fix example gen choose_rank context