### PR TITLE
[binary-log] Add CLI override to checkpoint parameters.

### DIFF
--- a/external_parser/event_processors/loop.h
+++ b/external_parser/event_processors/loop.h
@@ -6,10 +6,40 @@
 namespace v2 = reinforcement_learning::messages::flatbuff::v2;
 
 namespace loop {
+
+template<typename T>
+class sticky_value {
+  T _value;
+  bool _sticky; // once a value is set to sticky, it cannot be changed by further calls to set
+  bool _set;
+public:
+  sticky_value() : _sticky(false), _set(false), _value() {}
+  explicit sticky_value(T value) : _sticky(false), _set(true), _value(value) {}
+  void set(T value, bool sticky = false) {
+    if(!_sticky) {
+      _sticky = sticky;
+      _value = value;
+      _set = true;
+    }
+  }
+
+  //this should be used with trivial & small types, so copying is fine
+  T value() const { return _value; }
+
+  bool is_valid() const { return _set; }
+  bool is_sticky() const { return _sticky; }
+
+  operator T() const { return _value; }
+
+};
+
 struct loop_info {
-  float default_reward = 0.f;
-  v2::RewardFunctionType type = v2::RewardFunctionType_Earliest;
-  v2::LearningModeType learning_mode_config = v2::LearningModeType_Online;
-  v2::ProblemType problem_type_config = v2::ProblemType_UNKNOWN;
+  sticky_value<float> default_reward = sticky_value<float>(0.f);
+  sticky_value<v2::LearningModeType> learning_mode_config = sticky_value<v2::LearningModeType>(v2::LearningModeType_Online);
+  sticky_value<v2::ProblemType> problem_type_config;
+
+  bool is_configured() const {
+    return default_reward.is_valid()  && learning_mode_config.is_valid() && problem_type_config.is_valid();
+  }//&& type.is_valid()
 };
 } // namespace loop

--- a/external_parser/joiners/example_joiner.h
+++ b/external_parser/joiners/example_joiner.h
@@ -22,11 +22,15 @@ public:
 
   virtual ~example_joiner();
 
-  void set_reward_function(const v2::RewardFunctionType type) override;
-  void set_default_reward(float default_reward) override;
-  void set_learning_mode_config(v2::LearningModeType learning_mode) override;
-  void set_problem_type_config(v2::ProblemType problem_type) override;
+  void set_reward_function(const v2::RewardFunctionType type, bool sticky = false) override;
+  void set_default_reward(float default_reward, bool sticky = false) override;
+  void set_learning_mode_config(v2::LearningModeType learning_mode, bool sticky = false) override;
+  void set_problem_type_config(v2::ProblemType problem_type, bool sticky = false) override;
   bool joiner_ready() override;
+
+  float default_reward() const { return _loop_info.default_reward; }
+  v2::LearningModeType learning_mode_config() const { return _loop_info.learning_mode_config; }
+  v2::ProblemType problem_type_config() const { return _loop_info.problem_type_config; }
 
   // Takes an event which will have a timestamp and event payload
   // groups all events interactions with their event observations based on their
@@ -111,11 +115,10 @@ private:
   vw *_vw;
   flatbuffers::DetachedBuffer _detached_buffer;
 
-  reward::RewardFunctionType _reward_calculation;
+  loop::sticky_value<reward::RewardFunctionType> _reward_calculation;
   loop::loop_info _loop_info;
   metrics::joiner_metrics _joiner_metrics;
 
   bool _binary_to_json;
   std::ofstream _outfile;
-  bool _joiner_ready;
 };

--- a/external_parser/joiners/i_joiner.h
+++ b/external_parser/joiners/i_joiner.h
@@ -27,10 +27,10 @@ class i_joiner {
 public:
   virtual ~i_joiner() = default;
 
-  virtual void set_reward_function(const v2::RewardFunctionType type) = 0;
-  virtual void set_default_reward(float default_reward) = 0;
-  virtual void set_learning_mode_config(v2::LearningModeType learning_mode) = 0;
-  virtual void set_problem_type_config(v2::ProblemType problem_type) = 0;
+  virtual void set_reward_function(const v2::RewardFunctionType type, bool sticky = false) = 0;
+  virtual void set_default_reward(float default_reward, bool sticky = false) = 0;
+  virtual void set_learning_mode_config(v2::LearningModeType learning_mode, bool sticky = false) = 0;
+  virtual void set_problem_type_config(v2::ProblemType problem_type, bool sticky = false) = 0;
 
   /**
    * @brief Tells whether config was provided such that it can start joining examples.

--- a/external_parser/joiners/multistep_example_joiner.cc
+++ b/external_parser/joiners/multistep_example_joiner.cc
@@ -19,7 +19,7 @@
 
 
 multistep_example_joiner::multistep_example_joiner(vw *vw)
-    : _vw(vw), _reward_calculation(&reward::earliest), _joiner_ready(false) {}
+    : _vw(vw), _reward_calculation(&reward::earliest) {}
 
 multistep_example_joiner::~multistep_example_joiner() {
   // cleanup examples
@@ -56,50 +56,56 @@ bool multistep_example_joiner::process_event(const v2::JoinedEvent &joined_event
   return true;
 }
 
-void multistep_example_joiner::set_default_reward(float default_reward) {
-  _loop_info.default_reward = default_reward;
+void multistep_example_joiner::set_default_reward(float default_reward, bool sticky) {
+  _loop_info.default_reward.set(default_reward, sticky);
 }
 
-void multistep_example_joiner::set_learning_mode_config(v2::LearningModeType learning_mode) {
-  _loop_info.learning_mode_config = learning_mode;
+void multistep_example_joiner::set_learning_mode_config(
+    v2::LearningModeType learning_mode, bool sticky) {
+  _loop_info.learning_mode_config.set(learning_mode, sticky);
 }
 
-void multistep_example_joiner::set_problem_type_config(v2::ProblemType problem_type) {
-  _loop_info.problem_type_config = problem_type;
-  _joiner_ready = true;
+void multistep_example_joiner::set_problem_type_config(v2::ProblemType problem_type, bool sticky) {
+  _loop_info.problem_type_config.set(problem_type, sticky);
 }
 
 bool multistep_example_joiner::joiner_ready() {
-  return _joiner_ready;
+  return _loop_info.is_configured() && _reward_calculation.is_valid();
 }
 
-void multistep_example_joiner::set_reward_function(const v2::RewardFunctionType type) {
+void multistep_example_joiner::set_reward_function(const v2::RewardFunctionType type, bool sticky) {
+
+  reward::RewardFunctionType reward_calculation = nullptr;
   switch (type) {
   case v2::RewardFunctionType_Earliest:
-    _reward_calculation = &reward::earliest;
+    reward_calculation = &reward::earliest;
     break;
   case v2::RewardFunctionType_Average:
-    _reward_calculation = &reward::average;
+    reward_calculation = &reward::average;
     break;
 
   case v2::RewardFunctionType_Sum:
-    _reward_calculation = &reward::sum;
+    reward_calculation = &reward::sum;
     break;
 
   case v2::RewardFunctionType_Min:
-    _reward_calculation = &reward::min;
+    reward_calculation = &reward::min;
     break;
 
   case v2::RewardFunctionType_Max:
-    _reward_calculation = &reward::max;
+    reward_calculation = &reward::max;
     break;
 
   case v2::RewardFunctionType_Median:
-    _reward_calculation = &reward::median;
+    reward_calculation = &reward::median;
     break;
 
   default:
     break;
+  }
+  
+  if(reward_calculation) {
+    _reward_calculation.set(reward_calculation, sticky);
   }
 }
 

--- a/external_parser/joiners/multistep_example_joiner.h
+++ b/external_parser/joiners/multistep_example_joiner.h
@@ -29,10 +29,10 @@ public:
 
   virtual ~multistep_example_joiner();
 
-  void set_reward_function(const v2::RewardFunctionType type) override;
-  void set_default_reward(float default_reward) override;
-  void set_learning_mode_config(v2::LearningModeType learning_mode) override;
-  void set_problem_type_config(v2::ProblemType problem_type) override;
+  void set_reward_function(const v2::RewardFunctionType type, bool sticky) override;
+  void set_default_reward(float default_reward, bool sticky) override;
+  void set_learning_mode_config(v2::LearningModeType learning_mode, bool sticky) override;
+  void set_problem_type_config(v2::ProblemType problem_type, bool sticky) override;
   bool joiner_ready() override;
 
 
@@ -65,7 +65,7 @@ private:
   vw *_vw;
   flatbuffers::DetachedBuffer _detached_buffer;
 
-  reward::RewardFunctionType _reward_calculation;
+  loop::sticky_value<reward::RewardFunctionType> _reward_calculation;
   loop::loop_info _loop_info;
 
   std::unordered_map<std::string, std::vector<Parsed<v2::MultiStepEvent>>>
@@ -79,5 +79,4 @@ private:
   bool _sorted = false;
 
   metrics::joiner_metrics _joiner_metrics;
-  bool _joiner_ready;
 };

--- a/external_parser/parse_example_external.cc
+++ b/external_parser/parse_example_external.cc
@@ -16,6 +16,61 @@
 namespace VW {
 namespace external {
 
+std::array<std::pair<const char *, v2::ProblemType>, 4> const problem_types = {{
+  { "cb", v2::ProblemType_CB },
+  { "ccb", v2::ProblemType_CCB },
+  { "slates", v2::ProblemType_SLATES },
+  { "ca", v2::ProblemType_CA },
+}};
+
+bool str_to_problem_type(const std::string &str, v2::ProblemType &type) {
+  for(auto p : problem_types) {
+    if(!strcasecmp(p.first, str.c_str())) {
+      type = p.second;
+      return true;
+    }
+  }
+  type = v2::ProblemType_UNKNOWN;
+  return false;
+}
+
+std::array<std::pair<const char *, v2::RewardFunctionType>, 6> const reward_functions = {{
+  { "earliest", v2::RewardFunctionType_Earliest },
+  { "average", v2::RewardFunctionType_Average },
+  { "median", v2::RewardFunctionType_Median },
+  { "sum", v2::RewardFunctionType_Sum },
+  { "min", v2::RewardFunctionType_Min },
+  { "max", v2::RewardFunctionType_Max },
+}};
+
+bool str_to_reward_function(const std::string &str, v2::RewardFunctionType &reward_function) {
+  for(auto p : reward_functions) {
+    if(!strcasecmp(p.first, str.c_str())) {
+      reward_function = p.second;
+      return true;
+    }
+  }
+  reward_function = v2::RewardFunctionType_MIN;
+  return false;
+}
+
+std::array<std::pair<const char *, v2::LearningModeType>, 3> const learning_modes = {{
+  { "online", v2::LearningModeType_Online },
+  { "apprentice", v2::LearningModeType_Apprentice },
+  { "loggingonly", v2::LearningModeType_LoggingOnly },
+}};
+
+bool str_to_learning_mode(const std::string &str, v2::LearningModeType &mode) {
+  for(auto p : learning_modes) {
+    if(!strcasecmp(p.first, str.c_str())) {
+      mode = p.second;
+      return true;
+    }
+  }
+  mode = v2::LearningModeType_MIN;
+  return false;
+}
+
 bool parser_options::is_enabled() { return binary; }
 
 std::unique_ptr<parser>
@@ -46,6 +101,33 @@ parser::get_external_parser(vw *all, const input_options &parsed_options) {
     if (parsed_options.ext_opts->multistep) {
       joiner = VW::make_unique<multistep_example_joiner>(all);
     }
+
+    if(all->options->was_supplied("default_reward")) {
+      joiner->set_default_reward(parsed_options.ext_opts->default_reward, true);
+    }
+
+    if(all->options->was_supplied("problem_type")) {
+      v2::ProblemType problem_type;
+      if(!str_to_problem_type(parsed_options.ext_opts->problem_type, problem_type)) {
+        throw std::runtime_error("Invalid argument to --problem_type " + parsed_options.ext_opts->problem_type);
+      }
+      joiner->set_problem_type_config(problem_type, true);
+    }
+    if(all->options->was_supplied("learning_mode")) {
+      v2::LearningModeType learning_mode;
+      if(!str_to_learning_mode(parsed_options.ext_opts->learning_mode, learning_mode)) {
+        throw std::runtime_error("Invalid argument to --problem_type " + parsed_options.ext_opts->learning_mode);
+      }
+      joiner->set_learning_mode_config(learning_mode, true);
+    }
+    if(all->options->was_supplied("reward_function")) {
+      v2::RewardFunctionType reward_function;
+      if(!str_to_reward_function(parsed_options.ext_opts->reward_function, reward_function)) {
+        throw std::runtime_error("Invalid argument to --problem_type " + parsed_options.ext_opts->reward_function);
+      }
+      joiner->set_reward_function(reward_function, true);
+    }
+
     return VW::make_unique<binary_parser>(std::move(joiner));
   }
   throw std::runtime_error("external parser type not recognised");
@@ -65,7 +147,20 @@ void parser::set_parse_args(VW::config::option_group_definition &in_options,
         .help("convert binary joined log into dsjson format"))
     .add(
       VW::config::make_option("multistep", parsed_options.ext_opts->multistep)
-        .help("multistep binary joiner"));
+        .help("multistep binary joiner"))
+    .add(
+      VW::config::make_option("default_reward", parsed_options.ext_opts->default_reward)
+        .help("Override the default reward from the file"))
+    .add(
+      VW::config::make_option("problem_type", parsed_options.ext_opts->problem_type)
+        .help("Override the problem type trying to be solved, valid values: CB, CCB, SLATES, CA"))
+    .add(
+      VW::config::make_option("reward_function", parsed_options.ext_opts->reward_function)
+        .help("Override the reward function to be used, valid values: earliest, average, median, sum, min, max"))
+    .add(
+      VW::config::make_option("learning_mode", parsed_options.ext_opts->learning_mode)
+        .help("Override the learning mode from the file, valid values: Online, Apprentice, LoggingOnly"))
+    ;
 }
 
 void parser::persist_metrics(std::vector<std::pair<std::string, size_t>>& metrics) {

--- a/external_parser/parse_example_external.cc
+++ b/external_parser/parse_example_external.cc
@@ -12,6 +12,9 @@
 #include <memory>
 #include <cstdio>
 
+#ifndef _WIN32
+#define _stricmp strcasecmp
+#endif
 
 namespace VW {
 namespace external {

--- a/external_parser/parse_example_external.h
+++ b/external_parser/parse_example_external.h
@@ -15,6 +15,10 @@ struct parser_options {
   bool binary;
   bool binary_to_json;
   bool multistep;
+  float default_reward;
+  std::string problem_type;
+  std::string reward_function;
+  std::string learning_mode;
 };
 
 int parse_examples(vw *all, v_array<example *> &examples);

--- a/external_parser/unit_tests/test_example_joiner.cc
+++ b/external_parser/unit_tests/test_example_joiner.cc
@@ -160,3 +160,41 @@ BOOST_AUTO_TEST_CASE(example_joiner_test_cbb) {
   clear_examples(examples, vw);
   VW::finish(*vw);
 }
+
+BOOST_AUTO_TEST_CASE(example_joiner_test_joiner_ready) {
+  auto vw = VW::initialize("--quiet --binary_parser --cb_explore_adf", nullptr,
+                           false, nullptr, nullptr);
+
+  example_joiner joiner(vw);
+
+  //the initial state of the joiner is not ready
+  BOOST_CHECK_EQUAL(joiner.joiner_ready(), false);
+
+  //all values but problem type have a default value
+  joiner.set_problem_type_config(v2::ProblemType_CB);
+
+  BOOST_CHECK_EQUAL(joiner.joiner_ready(), true);
+}
+
+BOOST_AUTO_TEST_CASE(example_joiner_test_stickyness) {
+  auto vw = VW::initialize("--quiet --binary_parser --cb_explore_adf", nullptr,
+                           false, nullptr, nullptr);
+
+  example_joiner joiner(vw);
+
+  BOOST_CHECK_EQUAL(joiner.joiner_ready(), false);
+
+  //all values but problem type have a default value
+  joiner.set_problem_type_config(v2::ProblemType_CB, false);
+  BOOST_CHECK_EQUAL(joiner.problem_type_config(), v2::ProblemType_CB);
+
+  joiner.set_problem_type_config(v2::ProblemType_SLATES, true);
+  BOOST_CHECK_EQUAL(joiner.problem_type_config(), v2::ProblemType_SLATES);
+
+  // once the value is sticky, it cannot be modified
+  joiner.set_problem_type_config(v2::ProblemType_CB, false);
+  BOOST_CHECK_EQUAL(joiner.problem_type_config(), v2::ProblemType_SLATES);
+
+  joiner.set_problem_type_config(v2::ProblemType_CB, true);
+  BOOST_CHECK_EQUAL(joiner.problem_type_config(), v2::ProblemType_SLATES);
+}


### PR DESCRIPTION
CLI overrides must be sticky to be useful, so we introduce the notion of
sticky values that once set, can't be modified.

This is done by having a sticky_value<T> container in which the setter
takes an argument which controls the stickyness of the value. This way
we can use it for both CLI sources and file sources.