### PR TITLE
[Binary parser] refactoring rewards

### DIFF
--- a/external_parser/event_processors/joined_event.h
+++ b/external_parser/event_processors/joined_event.h
@@ -121,7 +121,6 @@ struct cb_joined_event : public typed_joined_event {
       if (interaction_metadata.learning_mode ==
           v2::LearningModeType_Apprentice) {
         if (should_calculate_apprentice_reward()) {
-          // je.interaction_data.actions[0] == je.baseline_action
           // TODO: default apprenticeReward should come from config
           // setting to default reward matches current behavior for now
           reward = original_reward;

--- a/external_parser/event_processors/loop.h
+++ b/external_parser/event_processors/loop.h
@@ -9,9 +9,9 @@ namespace loop {
 
 template<typename T>
 class sticky_value {
-  T _value;
   bool _sticky; // once a value is set to sticky, it cannot be changed by further calls to set
   bool _set;
+  T _value;
 public:
   sticky_value() : _sticky(false), _set(false), _value() {}
   explicit sticky_value(T value) : _sticky(false), _set(true), _value(value) {}

--- a/external_parser/event_processors/metadata.h
+++ b/external_parser/event_processors/metadata.h
@@ -1,0 +1,21 @@
+#pragma once
+
+// FileFormat_generated.h used for the payload type and encoding enum's
+#include "generated/v2/FileFormat_generated.h"
+
+#include "timestamp_helper.h"
+
+namespace v2 = reinforcement_learning::messages::flatbuff::v2;
+
+namespace metadata {
+// used both for interactions and observations
+struct event_metadata_info {
+  TimePoint client_time_utc;
+  std::string app_id;
+  v2::PayloadType payload_type;
+  float pass_probability;
+  v2::EventEncoding event_encoding;
+  std::string event_id;
+  v2::LearningModeType learning_mode;
+};
+} // namespace metadata

--- a/external_parser/event_processors/reward.h
+++ b/external_parser/event_processors/reward.h
@@ -1,14 +1,24 @@
 #pragma once
 
-#include "joined_event.h"
-
-namespace v2 = reinforcement_learning::messages::flatbuff::v2;
+#include "metadata.h"
 
 namespace reward {
+  
+struct outcome_event {
+  metadata::event_metadata_info metadata;
+  std::string s_index;
+  int index;
+  std::string s_value;
+  float value;
+  TimePoint enqueued_time_utc;
+  bool action_taken;
+};
 
-using RewardFunctionType = float (*)(const std::vector<joined_event::outcome_event> &);
+using RewardFunctionType =
+    float (*)(const std::vector<outcome_event> &);
 
-inline float average(const std::vector<joined_event::outcome_event> &outcome_events) {
+inline float
+average(const std::vector<outcome_event> &outcome_events) {
   float sum = 0.f;
   for (const auto &o : outcome_events) {
     sum += o.value;
@@ -17,7 +27,8 @@ inline float average(const std::vector<joined_event::outcome_event> &outcome_eve
   return sum / outcome_events.size();
 }
 
-inline float sum(const std::vector<joined_event::outcome_event> &outcome_events) {
+inline float
+sum(const std::vector<outcome_event> &outcome_events) {
   float sum = 0.f;
   for (const auto &o : outcome_events) {
     sum += o.value;
@@ -26,7 +37,8 @@ inline float sum(const std::vector<joined_event::outcome_event> &outcome_events)
   return sum;
 }
 
-inline float min(const std::vector<joined_event::outcome_event> &outcome_events) {
+inline float
+min(const std::vector<outcome_event> &outcome_events) {
   float min_reward = std::numeric_limits<float>::max();
   for (const auto &o : outcome_events) {
     if (o.value < min_reward) {
@@ -36,7 +48,8 @@ inline float min(const std::vector<joined_event::outcome_event> &outcome_events)
   return min_reward;
 }
 
-inline float max(const std::vector<joined_event::outcome_event> &outcome_events) {
+inline float
+max(const std::vector<outcome_event> &outcome_events) {
   float max_reward = std::numeric_limits<float>::min();
   for (const auto &o : outcome_events) {
     if (o.value > max_reward) {
@@ -46,7 +59,8 @@ inline float max(const std::vector<joined_event::outcome_event> &outcome_events)
   return max_reward;
 }
 
-inline float median(const std::vector<joined_event::outcome_event> &outcome_events) {
+inline float
+median(const std::vector<outcome_event> &outcome_events) {
   std::vector<float> values;
   for (const auto &o : outcome_events) {
     values.push_back(o.value);
@@ -64,7 +78,8 @@ inline float median(const std::vector<joined_event::outcome_event> &outcome_even
   }
 }
 
-inline float earliest(const std::vector<joined_event::outcome_event> &outcome_events) {
+inline float
+earliest(const std::vector<outcome_event> &outcome_events) {
   auto oldest_valid_observation = TimePoint::max();
   float earliest_reward = 0.f;
 

--- a/external_parser/joiners/multistep_example_joiner.cc
+++ b/external_parser/joiners/multistep_example_joiner.cc
@@ -117,10 +117,10 @@ void multistep_example_joiner::populate_order() {
   _sorted = true;
 }
 
-joined_event::outcome_event multistep_example_joiner::process_outcome(const multistep_example_joiner::Parsed<v2::OutcomeEvent> &event_meta) {
+reward::outcome_event multistep_example_joiner::process_outcome(const multistep_example_joiner::Parsed<v2::OutcomeEvent> &event_meta) {
   const auto& metadata = event_meta.meta;
   const auto& event = event_meta.event;
-  joined_event::outcome_event o_event;
+  reward::outcome_event o_event;
   o_event.metadata = {timestamp_to_chrono(*metadata.client_time_utc()),
                       metadata.app_id() ? metadata.app_id()->str() : "",
                       metadata.payload_type(),
@@ -142,7 +142,7 @@ joined_event::joined_event multistep_example_joiner::process_interaction(
     v_array<example *> &examples) {
   const auto& metadata = event_meta.meta;
   const auto& event = event_meta.event;
-  joined_event::metadata_info meta = {metadata.client_time_utc()
+  metadata::event_metadata_info meta = {metadata.client_time_utc()
                          ? timestamp_to_chrono(*metadata.client_time_utc())
                          : TimePoint(),
                         metadata.app_id() ? metadata.app_id()->str() : "",

--- a/external_parser/joiners/multistep_example_joiner.h
+++ b/external_parser/joiners/multistep_example_joiner.h
@@ -53,7 +53,7 @@ private:
 
 private:
   void populate_order();
-  joined_event::outcome_event
+  reward::outcome_event
   process_outcome(const Parsed<v2::OutcomeEvent> &event_meta);
   joined_event::joined_event
   process_interaction(const Parsed<v2::MultiStepEvent> &event_meta,

--- a/external_parser/log_converter.h
+++ b/external_parser/log_converter.h
@@ -13,7 +13,6 @@
 namespace v2 = reinforcement_learning::messages::flatbuff::v2;
 
 namespace log_converter {
-void build_cb_json(std::ofstream &outfile, const joined_event::joined_event &je,
-                   float reward, float original_reward,
-                   bool skip_learn = false);
+void build_cb_json(std::ofstream &outfile,
+                   const joined_event::joined_event &je);
 } // namespace log_converter


### PR DESCRIPTION
- moved `metadata_info` into it's own file/namespace since it is being used by both interactions and observations
- moved `outcome_event`'s to `reward.h`
- moved reward calculations from `example_joiner` to `joined_event`s