### PR TITLE
[Binary parser] only convert timestamp to string when we persist metrics

### DIFF
--- a/external_parser/event_processors/joined_event.h
+++ b/external_parser/event_processors/joined_event.h
@@ -359,29 +359,5 @@ struct joined_event {
     typed_data->calc_and_set_cost(examples, default_reward, reward_function,
                                   interaction_metadata, outcome_events);
   }
-
-  void calculate_metrics(dsjson_metrics *metrics) {
-    if (!metrics || !is_joined_event_learnable()) {
-      return;
-    }
-
-    if (metrics->FirstEventId.empty()) {
-      metrics->FirstEventId = interaction_metadata.event_id;
-    } else {
-      metrics->LastEventId = interaction_metadata.event_id;
-    }
-
-    // TODO does this potentially need to check and set client time utc if
-    // that option is on?
-    if (metrics->FirstEventTime.empty()) {
-      metrics->FirstEventTime = date::format(
-          "%FT%TZ",
-          date::floor<std::chrono::microseconds>(joined_event_timestamp));
-    } else {
-      metrics->LastEventTime = date::format(
-          "%FT%TZ",
-          date::floor<std::chrono::microseconds>(joined_event_timestamp));
-    }
-  }
 };
 } // namespace joined_event

--- a/external_parser/joiners/example_joiner.h
+++ b/external_parser/joiners/example_joiner.h
@@ -83,6 +83,8 @@ public:
 
   metrics::joiner_metrics get_metrics() override;
 
+  void persist_metrics() override;
+
 private:
   bool process_dedup(const v2::Event &event, const v2::Metadata &metadata);
 

--- a/external_parser/joiners/i_joiner.h
+++ b/external_parser/joiners/i_joiner.h
@@ -62,5 +62,7 @@ public:
 
   virtual void on_batch_read() = 0;
 
+  virtual void persist_metrics() {}
+
   virtual metrics::joiner_metrics get_metrics() = 0;
 };

--- a/external_parser/metrics/metrics.h
+++ b/external_parser/metrics/metrics.h
@@ -1,6 +1,13 @@
 #pragma once
 
+#include "event_processors/timestamp_helper.h"
+
 namespace metrics {
 struct joiner_metrics {
+  size_t number_of_skipped_events = 0;
+  TimePoint last_event_timestamp = TimePoint();
+  TimePoint first_event_timestamp = TimePoint();
+  std::string first_event_id = "";
+  std::string last_event_id = "";
 };
 } // namespace metrics

--- a/external_parser/parse_example_binary.cc
+++ b/external_parser/parse_example_binary.cc
@@ -306,9 +306,7 @@ bool binary_parser::advance_to_next_payload_type(io_buf *input,
 
 void binary_parser::persist_metrics(
     std::vector<std::pair<std::string, size_t>> &) {
-  // metrics::joiner_metrics joiner_metrics = _example_joiner->get_metrics();
-  // this isn't currently needed but leaving it here since we might want to
-  // persist more metrics in the future
+  _example_joiner->persist_metrics();
 }
 
 bool binary_parser::parse_examples(vw *all, v_array<example *> &examples) {


### PR DESCRIPTION
Moving the timestamp-to-string conversion at the end (i.e. when we have parsed all examples and are exiting and persisting the metrics) for perf reasons