### PR TITLE
Revert "mac ci: continue on error true (#327)"

### DIFF
--- a/.pipelines/build-macos.yml
+++ b/.pipelines/build-macos.yml
@@ -11,14 +11,10 @@ pool:
 steps:
 - checkout: self
   submodules: true
-  continueOnError: true
 - bash: .scripts/macos/restore.sh
   displayName: 'Restore dependencies'
-  continueOnError: true
 - bash: .scripts/macos/build.sh
   displayName: 'Build'
-  continueOnError: true
 - bash: .scripts/macos/test.sh
   displayName: 'Run tests'
-  continueOnError: true
 - task: PublishTestResults@2


### PR DESCRIPTION
This reverts commit 763c4c78eb2ea5eecc6901638ac6431e83dbb07b.

Mac CI currently fails. Either we should fix or remove. This would turn back on the failing CI.

Related:
https://github.com/VowpalWabbit/reinforcement_learning/issues/300

Reverts
https://github.com/VowpalWabbit/reinforcement_learning/pull/327