### PR TITLE
Fix CI's after flatbuffer version update to 2.0

### DIFF
--- a/rlclientlib/CMakeLists.txt
+++ b/rlclientlib/CMakeLists.txt
@@ -170,6 +170,8 @@ if(USE_ZSTD)
   target_include_directories(rlclientlib PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../ext_libs/zstd/lib/)
 endif()
 
+target_compile_definitions(rlclientlib PRIVATE FLATBUFFERS_SPAN_MINIMAL)
+
 target_include_directories( rlclientlib
                             PUBLIC
                             ${CMAKE_CURRENT_SOURCE_DIR}/../include

--- a/rlclientlib/rlclientlib.vcxproj
+++ b/rlclientlib/rlclientlib.vcxproj
@@ -80,7 +80,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(SkipAzureFactories)'!='true'">
     <ClCompile>
-      <PreprocessorDefinitions>USE_AZURE_FACTORIES;$(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_AZURE_FACTORIES;FLATBUFFERS_SPAN_MINIMAL;$(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/unit_test/unit_test.vcxproj
+++ b/unit_test/unit_test.vcxproj
@@ -83,7 +83,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(SkipAzureFactories)'!='true'">
     <ClCompile>
-      <PreprocessorDefinitions>USE_AZURE_FACTORIES;$(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_AZURE_FACTORIES;FLATBUFFERS_SPAN_MINIMAL;$(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">


### PR DESCRIPTION
this flag `FLATBUFFERS_SPAN_MINIMAL` compiles out flatbuffer code that uses concepts from c++17 like [`is_convertible_v`](https://en.cppreference.com/w/cpp/types/is_convertible) see [here](https://github.com/google/flatbuffers/blob/master/include/flatbuffers/stl_emulation.h#L499)

It will compile out the code introduced in this flatbuffer [PR](https://github.com/google/flatbuffers/pull/6663/files) for the usage of `span`