### PR TITLE
Update vowpalwabbit submodule

### DIFF
--- a/external_parser/event_processors/joined_event.h
+++ b/external_parser/event_processors/joined_event.h
@@ -49,7 +49,7 @@ struct typed_joined_event {
   virtual bool is_skip_learn() const = 0;
   virtual void set_skip_learn(bool sl) = 0;
   virtual void set_apprentice_reward() = 0;
-  virtual bool fill_in_label(v_array<example *> &examples, VW::io::logger& logger) const = 0;
+  virtual bool fill_in_label(VW::multi_ex &examples, VW::io::logger& logger) const = 0;
   virtual void
   calc_cost(float default_reward, reward::RewardFunctionType reward_function,
             const metadata::event_metadata_info &interaction_metadata,
@@ -88,7 +88,7 @@ struct cb_joined_event : public typed_joined_event {
     }
   }
 
-  bool fill_in_label(v_array<example *> &examples,
+  bool fill_in_label(VW::multi_ex &examples,
                      VW::io::logger &logger) const override {
     if (interaction_data.actions.empty()) {
       logger.out_warn("missing actions for event [{}]",
@@ -187,7 +187,7 @@ struct ccb_joined_event : public typed_joined_event {
     }
   }
 
-  bool fill_in_label(v_array<example *> &examples,
+  bool fill_in_label(VW::multi_ex &examples,
                      VW::io::logger &logger) const override {
     // index to interaction_data vector which holds per-slot info
     size_t slot_index = 0;
@@ -318,7 +318,7 @@ struct slates_joined_event : public typed_joined_event {
 
   void set_apprentice_reward() override {}
 
-  bool fill_in_label(v_array<example *> &examples,
+  bool fill_in_label(VW::multi_ex &examples,
                      VW::io::logger &logger) const override {
     size_t slot_index = 0;
     auto weight = 1.f / (1.f - multi_slot_interaction.probability_of_drop);
@@ -415,7 +415,7 @@ struct ca_joined_event : public typed_joined_event {
     }
   }
 
-  bool fill_in_label(v_array<example *> &examples,
+  bool fill_in_label(VW::multi_ex &examples,
                      VW::io::logger &logger) const override {
 
     if (std::isnan(interaction_data.action)) {
@@ -495,7 +495,7 @@ struct joined_event {
     return typed_data->set_apprentice_reward();
   }
 
-  bool fill_in_label(v_array<example *> &examples,
+  bool fill_in_label(VW::multi_ex &examples,
                      VW::io::logger &logger) const {
     return typed_data->fill_in_label(examples, logger);
   }
@@ -545,7 +545,7 @@ struct multistep_joined_event {
   std::unique_ptr<cb_joined_event> cb_data;
   std::vector<reward::outcome_event> outcome_events;
 
-  bool fill_in_label(v_array<example *> &examples, VW::io::logger& logger) const {
+  bool fill_in_label(VW::multi_ex &examples, VW::io::logger& logger) const {
     return cb_data->fill_in_label(examples, logger);
   }
 

--- a/external_parser/joiners/example_joiner.cc
+++ b/external_parser/joiners/example_joiner.cc
@@ -170,7 +170,7 @@ void example_joiner::clear_batch_info() {
   }
 }
 
-void example_joiner::clear_vw_examples(v_array<example *> &examples) {
+void example_joiner::clear_vw_examples(VW::multi_ex &examples) {
   // cleanup examples since something might have gone wrong and left the
   // existing example's in a bad state
   VW::return_multiple_example(*_vw, examples);
@@ -196,7 +196,7 @@ void example_joiner::invalidate_joined_event(const std::string &id) {
 bool example_joiner::process_interaction(const v2::Event &event,
                                          const v2::Metadata &metadata,
                                          const TimePoint &enqueued_time_utc,
-                                         v_array<example *> &examples) {
+                                         VW::multi_ex &examples) {
 
   std::string payload_type(EnumNamePayloadType(metadata.payload_type()));
   std::string loop_type(EnumNameProblemType(_loop_info.problem_type_config));
@@ -377,7 +377,7 @@ bool example_joiner::process_dedup(const v2::Event &event,
     return false;
   }
 
-  v_array<example *> examples;
+  VW::multi_ex examples;
 
   for (flatbuffers::uoffset_t i = 0; i < dedup->ids()->size(); i++) {
     auto dedup_id = dedup->ids()->Get(i);
@@ -420,7 +420,7 @@ bool example_joiner::process_dedup(const v2::Event &event,
   return true;
 }
 
-bool example_joiner::process_joined(v_array<example *> &examples) {
+bool example_joiner::process_joined(VW::multi_ex &examples) {
   _current_je_is_skip_learn = false;
 
   if (_batch_event_order.empty()) {

--- a/external_parser/joiners/example_joiner.h
+++ b/external_parser/joiners/example_joiner.h
@@ -70,7 +70,7 @@ public:
    * We can't attempt to invalidate the specific id since we don't know it (it's
    * in the metadata)
    */
-  bool process_joined(v_array<example *> &examples) override;
+  bool process_joined(VW::multi_ex &examples) override;
 
   // true if there are still event-groups to be processed from a deserialized
   // batch
@@ -94,7 +94,7 @@ private:
 
   bool process_interaction(const v2::Event &event, const v2::Metadata &metadata,
                            const TimePoint &enqueued_time_utc,
-                           v_array<example *> &examples);
+                           VW::multi_ex &examples);
 
   bool process_outcome(const v2::Event &event, const v2::Metadata &metadata,
                        const TimePoint &enqueued_time_utc);
@@ -102,7 +102,7 @@ private:
   void clear_batch_info();
   void clear_event_id_batch_info(const std::string &id);
   void invalidate_joined_event(const std::string &id);
-  void clear_vw_examples(v_array<example *> &examples);
+  void clear_vw_examples(VW::multi_ex &examples);
 
   example *get_or_create_example();
 

--- a/external_parser/joiners/i_joiner.h
+++ b/external_parser/joiners/i_joiner.h
@@ -53,7 +53,7 @@ public:
   // Takes all grouped events, processes them (e.g. decompression) and populates
   // the examples array with complete example(s) ready to be used by vw for
   // training
-  virtual bool process_joined(v_array<example *> &examples) = 0;
+  virtual bool process_joined(VW::multi_ex &examples) = 0;
   // true if there are still event-groups to be processed from a deserialized
   // batch
   virtual bool processing_batch() = 0;

--- a/external_parser/joiners/multistep_example_joiner.cc
+++ b/external_parser/joiners/multistep_example_joiner.cc
@@ -226,7 +226,7 @@ reward::outcome_event multistep_example_joiner::process_outcome(
 
 joined_event::multistep_joined_event multistep_example_joiner::process_interaction(
     const multistep_example_joiner::Parsed<v2::MultiStepEvent> &event_meta,
-    v_array<example *> &examples) {
+    VW::multi_ex &examples) {
   const auto& metadata = event_meta.meta;
   const auto& event = event_meta.event;
   metadata::event_metadata_info meta = {
@@ -264,7 +264,7 @@ joined_event::multistep_joined_event multistep_example_joiner::process_interacti
   return joined_event::multistep_joined_event(std::move(meta), std::move(cb_data));
 }
 
-bool multistep_example_joiner::process_joined(v_array<example *> &examples) {
+bool multistep_example_joiner::process_joined(VW::multi_ex &examples) {
   _current_je_is_skip_learn = false;
 
   if (!_sorted) {

--- a/external_parser/joiners/multistep_example_joiner.h
+++ b/external_parser/joiners/multistep_example_joiner.h
@@ -72,7 +72,7 @@ public:
   bool current_event_is_skip_learn() override;
 
   bool process_event(const v2::JoinedEvent &joined_event) override;
-  bool process_joined(v_array<example *> &examples) override;
+  bool process_joined(VW::multi_ex &examples) override;
   bool processing_batch() override;
 
   void on_new_batch() override;
@@ -93,7 +93,7 @@ private:
   process_outcome(const TimePoint& timestamp, const v2::Metadata &metadata, const v2::OutcomeEvent& event);
   joined_event::multistep_joined_event
   process_interaction(const Parsed<v2::MultiStepEvent> &event_meta,
-                      v_array<example *> &examples);
+                      VW::multi_ex &examples);
   void populate_episodic_rewards();
 
 private:

--- a/external_parser/parse_example_binary.cc
+++ b/external_parser/parse_example_binary.cc
@@ -201,7 +201,7 @@ bool binary_parser::read_checkpoint_msg(io_buf &input) {
 }
 
 bool binary_parser::read_regular_msg(io_buf &input,
-                                     v_array<example *> &examples,
+                                     VW::multi_ex &examples,
                                      bool &ignore_msg) {
   _payload = nullptr;
   ignore_msg = false;
@@ -264,7 +264,7 @@ bool binary_parser::read_regular_msg(io_buf &input,
   return process_next_in_batch(examples);
 }
 
-bool binary_parser::process_next_in_batch(v_array<example *> &examples) {
+bool binary_parser::process_next_in_batch(VW::multi_ex &examples) {
   while (_example_joiner->processing_batch()) {
     if (_example_joiner->process_joined(examples)) {
       return true;
@@ -312,7 +312,7 @@ void binary_parser::persist_metrics(metric_sink &) {
 }
 
 bool binary_parser::parse_examples(VW::workspace*, io_buf &io_buf,
-                                   v_array<example *> &examples) {
+                                   VW::multi_ex &examples) {
   if (process_next_in_batch(examples)) {
     return true;
   }

--- a/external_parser/parse_example_binary.h
+++ b/external_parser/parse_example_binary.h
@@ -24,18 +24,18 @@ public:
       std::unique_ptr<i_joiner> &&joiner, VW::io::logger logger); // taking ownership of joiner
   ~binary_parser();
   bool parse_examples(VW::workspace *all, io_buf &io_buf,
-                      v_array<example *> &examples) override;
+                      VW::multi_ex &examples) override;
   bool read_version(io_buf &input);
   bool read_header(io_buf &input);
   bool read_checkpoint_msg(io_buf &input);
-  bool read_regular_msg(io_buf &input, v_array<example *> &examples,
+  bool read_regular_msg(io_buf &input, VW::multi_ex &examples,
                         bool &ignore_msg);
   bool skip_over_unknown_payload(io_buf &input);
   bool advance_to_next_payload_type(io_buf &input, unsigned int &payload_type);
   void persist_metrics(metric_sink &metrics) override;
 
 private:
-  bool process_next_in_batch(v_array<example *> &examples);
+  bool process_next_in_batch(VW::multi_ex &examples);
   std::unique_ptr<i_joiner> _example_joiner;
   char *_payload;
   uint32_t _payload_size;

--- a/external_parser/parse_example_converter.cc
+++ b/external_parser/parse_example_converter.cc
@@ -16,7 +16,7 @@ binary_json_converter::binary_json_converter(std::unique_ptr<i_joiner> &&joiner,
 binary_json_converter::~binary_json_converter() = default;
 
 bool binary_json_converter::parse_examples(VW::workspace *all, io_buf &io_buf,
-                                           v_array<example *> &examples) {
+                                           VW::multi_ex &examples) {
   while (_parser.parse_examples(all, io_buf, examples)) {
     // do nothing
   }

--- a/external_parser/parse_example_converter.h
+++ b/external_parser/parse_example_converter.h
@@ -15,7 +15,7 @@ class binary_json_converter : public parser {
 public:
   binary_json_converter(std::unique_ptr<i_joiner>&& joiner, VW::io::logger logger);  //taking ownership of joiner
   ~binary_json_converter();
-  bool parse_examples(VW::workspace *all, io_buf& io_buf, v_array<example *> &examples) override;
+  bool parse_examples(VW::workspace *all, io_buf& io_buf, VW::multi_ex &examples) override;
   void persist_metrics(metric_sink& metrics_sink) override;
 
 private:

--- a/external_parser/parse_example_external.cc
+++ b/external_parser/parse_example_external.cc
@@ -153,7 +153,7 @@ void parser::persist_metrics(metric_sink& metric_sink) {
   metric_sink.set_uint("external_parser", 1);
 }
 
-int parse_examples(VW::workspace *all, io_buf& io_buf, v_array<example *> &examples) {
+int parse_examples(VW::workspace *all, io_buf& io_buf, VW::multi_ex &examples) {
   bool keep_reading = all->custom_parser->next(*all, io_buf, examples);
   return keep_reading ? 1 : 0;
 }

--- a/external_parser/parse_example_external.h
+++ b/external_parser/parse_example_external.h
@@ -39,7 +39,7 @@ public:
                               VW::multi_ex &examples) = 0;
   virtual void persist_metrics(metric_sink &metrics);
 
-  bool next(VW::workspace& workspace_instance, io_buf& buffer, VW::v_array<VW::example*>& output_examples) override
+  bool next(VW::workspace& workspace_instance, io_buf& buffer, VW::multi_ex& output_examples) override
   {
     return parse_examples(&workspace_instance, buffer, output_examples);
   }

--- a/external_parser/parse_example_external.h
+++ b/external_parser/parse_example_external.h
@@ -25,7 +25,7 @@ struct parser_options {
   bool use_client_time;
 };
 
-int parse_examples(VW::workspace *all, io_buf &io_buf, v_array<example *> &examples);
+int parse_examples(VW::workspace *all, io_buf &io_buf, VW::multi_ex &examples);
 
 class parser : public VW::details::input_parser {
 public:
@@ -36,7 +36,7 @@ public:
                              parser_options &parsed_options);
   virtual ~parser() = default;
   virtual bool parse_examples(VW::workspace *all, io_buf &io_buf,
-                              v_array<example *> &examples) = 0;
+                              VW::multi_ex &examples) = 0;
   virtual void persist_metrics(metric_sink &metrics);
 
   bool next(VW::workspace& workspace_instance, io_buf& buffer, VW::v_array<VW::example*>& output_examples) override

--- a/external_parser/unit_tests/test_client_and_enqueued_time.cc
+++ b/external_parser/unit_tests/test_client_and_enqueued_time.cc
@@ -4,7 +4,7 @@
 #include "vw/core/memory.h"
 #include <boost/test/unit_test.hpp>
 
-void process(VW::workspace *vw, example_joiner &joiner, v_array<example *> &examples,
+void process(VW::workspace *vw, example_joiner &joiner, VW::multi_ex &examples,
              std::string int_file, std::string obs_file) {
   std::string input_files = get_test_files_location();
 
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(test_use_client_time_missing_and_configured_to_true) {
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
   example_joiner joiner(vw.get());
-  v_array<example *> examples;
+  VW::multi_ex examples;
 
   joiner.set_problem_type_config(v2::ProblemType_CB);
   // the test files used do not have a client time utc set, so they will use the
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(test_use_client_time_existing_and_configured_to_false) {
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
   example_joiner joiner(vw.get());
-  v_array<example *> examples;
+  VW::multi_ex examples;
 
   joiner.set_problem_type_config(v2::ProblemType_CB);
   // the test files used have a client time utc set, but enqueued time will be
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(test_use_client_time_existing_and_configured_to_true) {
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
   example_joiner joiner(vw.get());
-  v_array<example *> examples;
+  VW::multi_ex examples;
 
   joiner.set_problem_type_config(v2::ProblemType_CB);
   // the test files used have a client time set and it should be used instead of

--- a/external_parser/unit_tests/test_common.cc
+++ b/external_parser/unit_tests/test_common.cc
@@ -30,13 +30,13 @@ uint32_t from_network_order(std::uint32_t net_l) {
 }
 } // end of namespace endian
 
-void set_slates_label(v_array<example *> &examples) {
+void set_slates_label(VW::multi_ex &examples) {
   examples[0]->pred.decision_scores.resize(2);
   examples[0]->pred.decision_scores[0].push_back({0, 0.f});
   examples[0]->pred.decision_scores[1].push_back({1, 0.f});
 }
 
-void clear_examples(v_array<example *> &examples, VW::workspace *vw) {
+void clear_examples(VW::multi_ex &examples, VW::workspace *vw) {
   if (vw->l->is_multiline()) {
     multi_ex multi_exs;
     for (auto *ex : examples) {

--- a/external_parser/unit_tests/test_common.h
+++ b/external_parser/unit_tests/test_common.h
@@ -17,9 +17,9 @@ constexpr float FLOAT_TOL = 0.0001f;
 
 // learn/predict isn't called in the unit test but cleanup examples
 // expects shared pred to be set for slates
-void set_slates_label(v_array<example *> &examples);
+void set_slates_label(VW::multi_ex &examples);
 
-void clear_examples(v_array<example *> &examples, VW::workspace *vw);
+void clear_examples(VW::multi_ex &examples, VW::workspace *vw);
 
 void set_buffer_as_vw_input(const std::vector<char> &buffer, VW::workspace *vw);
 

--- a/external_parser/unit_tests/test_example_joiner.cc
+++ b/external_parser/unit_tests/test_example_joiner.cc
@@ -10,7 +10,7 @@ BOOST_AUTO_TEST_CASE(example_joiner_test_ca) {
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
   example_joiner joiner(vw.get());
-  v_array<example *> examples;
+  VW::multi_ex examples;
   joiner.set_problem_type_config(v2::ProblemType_CA);
   std::string input_files = get_test_files_location();
   auto interaction_buffer = read_file(input_files + "/fb_events/ca_v2.fb");
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(example_joiner_test_cb) {
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
   example_joiner joiner(vw.get());
-  v_array<example *> examples;
+  VW::multi_ex examples;
 
   joiner.set_problem_type_config(v2::ProblemType_CB);
 
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(example_joiner_test_cbb) {
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
   example_joiner joiner(vw.get());
-  v_array<example *> examples;
+  VW::multi_ex examples;
 
   joiner.set_problem_type_config(v2::ProblemType_CCB);
 

--- a/external_parser/unit_tests/test_log_converter.cc
+++ b/external_parser/unit_tests/test_log_converter.cc
@@ -35,7 +35,7 @@ std::string get_json_event(std::string infile_path, std::string outfile_path,
   auto options = VW::make_unique<VW::config::options_cli>(VW::split_command_line(command));
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
 
   while (vw->example_parser->reader(vw.get(), vw->example_parser->input, examples) > 0) {

--- a/external_parser/unit_tests/test_lru_dedup_cache.cc
+++ b/external_parser/unit_tests/test_lru_dedup_cache.cc
@@ -8,7 +8,7 @@ BOOST_AUTO_TEST_CASE(test_lru_add_new_examples_to_cache) {
   auto options = VW::make_unique<VW::config::options_cli>(std::vector<std::string>{"--quiet", "--binary_parser", "--cb_explore_adf"});
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
   // create a dummy examples to be cached
   examples[0]->indices.push_back('A');
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(test_lru_update) {
   auto options = VW::make_unique<VW::config::options_cli>(std::vector<std::string>{"--quiet", "--binary_parser", "--cb_explore_adf"});
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
 
   // create a dummy examples to be cached

--- a/external_parser/unit_tests/test_reward_functions.cc
+++ b/external_parser/unit_tests/test_reward_functions.cc
@@ -36,7 +36,7 @@ std::vector<float> get_float_rewards(
   auto options = VW::make_unique<VW::config::options_cli>(VW::split_command_line(command));
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
-  v_array<example *> examples;
+  VW::multi_ex examples;
   example_joiner joiner(vw.get());
 
   joiner.set_problem_type_config(problem_type);

--- a/external_parser/unit_tests/test_skip_learn.cc
+++ b/external_parser/unit_tests/test_skip_learn.cc
@@ -33,7 +33,7 @@ void should_not_add_examples(std::string &infile,
   auto options = VW::make_unique<VW::config::options_cli>(VW::split_command_line(command + " -d " + infile_name));
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
 
   while (vw->example_parser->reader(vw.get(), vw->example_parser->input, examples) > 0) {
@@ -72,7 +72,7 @@ void should_add_examples(std::string &infile,
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
 
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
 
   while (vw->example_parser->reader(vw.get(), vw->example_parser->input, examples) > 0) {

--- a/external_parser/unit_tests/test_vw_binary_parser.cc
+++ b/external_parser/unit_tests/test_vw_binary_parser.cc
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(test_log_file_with_unknown_msg_type) {
                             vw->example_parser->input, payload_type),
                         true);
     BOOST_REQUIRE_EQUAL(payload_type, MSG_TYPE_REGULAR);
-    v_array<example *> examples;
+    VW::multi_ex examples;
     examples.push_back(VW::new_unused_example(*vw));
     bool ignore_msg = false;
     BOOST_REQUIRE_EQUAL(bp.read_regular_msg(vw->example_parser->input, examples, ignore_msg),
@@ -171,7 +171,7 @@ BOOST_AUTO_TEST_CASE(test_log_file_with_unknown_msg_type) {
     auto vw = VW::external::initialize_with_binary_parser(std::move(options));
     set_buffer_as_vw_input(buffer, vw.get());
     VW::external::binary_parser bp(VW::make_unique<example_joiner>(vw.get()), vw->logger);
-    v_array<example *> examples;
+    VW::multi_ex examples;
     examples.push_back(VW::new_unused_example(*vw));
 
     size_t total_examples_read = 0;
@@ -198,7 +198,7 @@ BOOST_AUTO_TEST_CASE(test_log_file_with_corrupt_joined_event_payload) {
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
   set_buffer_as_vw_input(buffer, vw.get());
   VW::external::binary_parser bp(VW::make_unique<example_joiner>(vw.get()), vw->logger);
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
 
   size_t total_size_of_examples = 0;
@@ -229,7 +229,7 @@ BOOST_AUTO_TEST_CASE(test_log_file_with_mismatched_payload_types) {
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
   set_buffer_as_vw_input(buffer, vw.get());
   VW::external::binary_parser bp(VW::make_unique<example_joiner>(vw.get()), vw->logger);
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
 
   size_t total_size_of_examples = 0;
@@ -255,7 +255,7 @@ BOOST_AUTO_TEST_CASE(test_log_file_with_bad_event_in_joined_event) {
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
   set_buffer_as_vw_input(buffer, vw.get());
   VW::external::binary_parser bp(VW::make_unique<example_joiner>(vw.get()),vw->logger);
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
 
   size_t total_size_of_examples = 0;
@@ -285,7 +285,7 @@ BOOST_AUTO_TEST_CASE(test_log_file_with_dedup_payload_missing) {
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
   set_buffer_as_vw_input(buffer, vw.get());
   VW::external::binary_parser bp(VW::make_unique<example_joiner>(vw.get()), vw->logger);
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
 
   size_t total_size_of_examples = 0;
@@ -315,7 +315,7 @@ BOOST_AUTO_TEST_CASE(test_log_file_with_interaction_but_no_observation) {
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
   set_buffer_as_vw_input(buffer, vw.get());
   VW::external::binary_parser bp(VW::make_unique<example_joiner>(vw.get()), vw->logger);
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
 
   size_t total_size_of_examples = 0;
@@ -361,7 +361,7 @@ BOOST_AUTO_TEST_CASE(test_log_file_with_no_interaction_with_observation) {
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
   set_buffer_as_vw_input(buffer, vw.get());
   VW::external::binary_parser bp(VW::make_unique<example_joiner>(vw.get()), vw->logger);
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
 
   size_t total_size_of_examples = 0;
@@ -391,7 +391,7 @@ BOOST_AUTO_TEST_CASE(test_log_file_with_invalid_cb_context) {
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
   set_buffer_as_vw_input(buffer, vw.get());
   VW::external::binary_parser bp(VW::make_unique<example_joiner>(vw.get()), vw->logger);
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
 
   size_t total_size_of_examples = 0;

--- a/external_parser/unit_tests/test_vw_external_parser.cc
+++ b/external_parser/unit_tests/test_vw_external_parser.cc
@@ -14,7 +14,7 @@ BOOST_AUTO_TEST_CASE(cb_simple) {
   auto options = VW::make_unique<VW::config::options_cli>(std::vector<std::string>{"--quiet","--binary_parser","--cb_explore_adf"});
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
 
   set_buffer_as_vw_input(buffer, vw.get());
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(ccb_simple) {
   auto options = VW::make_unique<VW::config::options_cli>(std::vector<std::string>{"--quiet","--binary_parser","--ccb_explore_adf"});
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
 
   set_buffer_as_vw_input(buffer, vw.get());
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(slates_simple) {
   auto options = VW::make_unique<VW::config::options_cli>(std::vector<std::string>{"--quiet","--binary_parser","--ccb_explore_adf", "--slates"});
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
 
   set_buffer_as_vw_input(buffer, vw.get());
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE(cb_dedup_compressed) {
   auto options = VW::make_unique<VW::config::options_cli>(std::vector<std::string>{"--quiet","--binary_parser","--cb_explore_adf"});
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
   set_buffer_as_vw_input(buffer, vw.get());
 
@@ -245,7 +245,7 @@ BOOST_AUTO_TEST_CASE(cb_compare_dsjson_with_fb_models_ignore_feature) {
 
   std::string file_name =
       input_files + "/valid_joined_logs/average_reward_100_interactions";
-  
+
   auto vw_command = "--cb_explore_adf --ignore_features_dsjson_experimental GUser|hobby";
   generate_dsjson_and_fb_models(model_name, vw_command, file_name);
 
@@ -260,7 +260,7 @@ BOOST_AUTO_TEST_CASE(cb_compare_dsjson_with_fb_models_ignore_multiple_feature) {
 
   std::string file_name =
       input_files + "/valid_joined_logs/average_reward_100_interactions";
-  
+
   auto vw_command = "--cb_explore_adf --ignore_features_dsjson_experimental GUser|hobby TAction|a1";
   generate_dsjson_and_fb_models(model_name, vw_command, file_name);
 
@@ -343,7 +343,7 @@ BOOST_AUTO_TEST_CASE(slates_skip_learn_w_activations) {
   auto options = VW::make_unique<VW::config::options_cli>(std::vector<std::string>{"--ccb_explore_adf","--slates","--binary_parser","--quiet"});
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
 
   set_buffer_as_vw_input(buffer, vw.get());
@@ -392,7 +392,7 @@ BOOST_AUTO_TEST_CASE(rrcr_ignore_examples_before_checkpoint) {
   auto options = VW::make_unique<VW::config::options_cli>(std::vector<std::string>{"--quiet","--binary_parser","--cb_explore_adf"});
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
 
   set_buffer_as_vw_input(buffer, vw.get());
@@ -418,7 +418,7 @@ BOOST_AUTO_TEST_CASE(rcrrmr_file_magic_and_header_in_the_middle_works) {
   auto options = VW::make_unique<VW::config::options_cli>(std::vector<std::string>{"--quiet","--binary_parser","--cb_explore_adf"});
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
 
   set_buffer_as_vw_input(buffer, vw.get());
@@ -451,7 +451,7 @@ BOOST_AUTO_TEST_CASE(cb_apprentice_mode) {
   auto options = VW::make_unique<VW::config::options_cli>(std::vector<std::string>{"--quiet","--binary_parser","--cb_explore_adf"});
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
 
   set_buffer_as_vw_input(buffer, vw.get());
@@ -511,7 +511,7 @@ BOOST_AUTO_TEST_CASE(cb_skip_learn_w_activations_and_apprentice) {
   auto options = VW::make_unique<VW::config::options_cli>(std::vector<std::string>{"--quiet","--binary_parser","--cb_explore_adf"});
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
 
   set_buffer_as_vw_input(buffer, vw.get());
@@ -565,7 +565,7 @@ BOOST_AUTO_TEST_CASE(ccb_apprentice_mode) {
   auto options = VW::make_unique<VW::config::options_cli>(std::vector<std::string>{"--quiet","--binary_parser","--ccb_explore_adf"});
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
 
   set_buffer_as_vw_input(buffer, vw.get());
@@ -659,7 +659,7 @@ BOOST_AUTO_TEST_CASE(ccb_skip_learn_w_activations_and_apprentice) {
   auto options = VW::make_unique<VW::config::options_cli>(std::vector<std::string>{"--quiet","--binary_parser","--cb_explore_adf"});
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
 
   set_buffer_as_vw_input(buffer, vw.get());
@@ -708,7 +708,7 @@ BOOST_AUTO_TEST_CASE(cb_pdrop_05_parse) {
   auto options = VW::make_unique<VW::config::options_cli>(std::vector<std::string>{"--quiet","--binary_parser","--cb_explore_adf"});
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
   set_buffer_as_vw_input(buffer, vw.get());
 
@@ -739,7 +739,7 @@ BOOST_AUTO_TEST_CASE(cb_pdrop_1_parse) {
   auto options = VW::make_unique<VW::config::options_cli>(std::vector<std::string>{"--quiet","--binary_parser","--cb_explore_adf"});
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
   set_buffer_as_vw_input(buffer, vw.get());
 
@@ -769,7 +769,7 @@ BOOST_AUTO_TEST_CASE(multistep_2_episodes) {
   auto options = VW::make_unique<VW::config::options_cli>(std::vector<std::string>{"--cb_explore_adf","--binary_parser","--quiet","--multistep","--multistep_reward","identity"});
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
   set_buffer_as_vw_input(buffer, vw.get());
 
@@ -842,7 +842,7 @@ BOOST_AUTO_TEST_CASE(multistep_3_deferred_episodes) {
   auto options = VW::make_unique<VW::config::options_cli>(std::vector<std::string>{"--cb_explore_adf","--binary_parser","--quiet","--multistep","--multistep_reward","identity"});
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
   set_buffer_as_vw_input(buffer, vw.get());
 
@@ -923,7 +923,7 @@ BOOST_AUTO_TEST_CASE(multistep_unordered_episodes) {
   auto options = VW::make_unique<VW::config::options_cli>(std::vector<std::string>{"--cb_explore_adf","--binary_parser","--quiet","--multistep","--multistep_reward","identity"});
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
   set_buffer_as_vw_input(buffer, vw.get());
 
@@ -998,7 +998,7 @@ BOOST_AUTO_TEST_CASE(multistep_2_episodes_suffix_mean) {
   auto options = VW::make_unique<VW::config::options_cli>(std::vector<std::string>{"--cb_explore_adf","--binary_parser","--quiet","--multistep","--multistep_reward","suffix_mean"});
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
   set_buffer_as_vw_input(buffer, vw.get());
 
@@ -1054,7 +1054,7 @@ BOOST_AUTO_TEST_CASE(multistep_2_episodes_suffix_sum) {
   auto options = VW::make_unique<VW::config::options_cli>(std::vector<std::string>{"--cb_explore_adf","--binary_parser","--quiet","--multistep","--multistep_reward","suffix_sum"});
   auto vw = VW::external::initialize_with_binary_parser(std::move(options));
 
-  v_array<example *> examples;
+  VW::multi_ex examples;
   examples.push_back(VW::new_unused_example(*vw));
   set_buffer_as_vw_input(buffer, vw.get());
 

--- a/rlclientlib/vw_model/safe_vw.cc
+++ b/rlclientlib/vw_model/safe_vw.cc
@@ -1,6 +1,7 @@
 #include "safe_vw.h"
 
 // VW headers
+#include "vw/core/debug_print.h"
 #include "vw/core/example.h"
 #include "vw/core/parse_example_json.h"
 #include "vw/core/parser.h"
@@ -80,7 +81,7 @@ namespace reinforcement_learning {
   {
     DecisionServiceInteraction interaction;
 
-    v_array<example*> examples;
+    VW::multi_ex examples;
     examples.push_back(get_or_create_example());
 
     //copy due to destructive parsing by rapidjson
@@ -107,7 +108,7 @@ namespace reinforcement_learning {
 
   void safe_vw::rank(string_view context, std::vector<int>& actions, std::vector<float>& scores)
   {
-    v_array<example*> examples;
+    VW::multi_ex examples;
     examples.push_back(get_or_create_example());
 
     //copy due to destructive parsing by rapidjson
@@ -141,7 +142,7 @@ namespace reinforcement_learning {
 
   void safe_vw::choose_continuous_action(string_view context, float& action, float& pdf_value)
   {
-    v_array<example*> examples;
+    VW::multi_ex examples;
     examples.push_back(get_or_create_example());
 
     //copy due to destructive parsing by rapidjson
@@ -165,7 +166,7 @@ namespace reinforcement_learning {
 
   void safe_vw::rank_decisions(const std::vector<const char*>& event_ids, string_view context, std::vector<std::vector<uint32_t>>& actions, std::vector<std::vector<float>>& scores)
   {
-    v_array<example*> examples;
+    VW::multi_ex examples;
     examples.push_back(get_or_create_example());
 
     //copy due to destructive parsing by rapidjson
@@ -212,7 +213,7 @@ namespace reinforcement_learning {
 
   void safe_vw::rank_multi_slot_decisions(const char* event_id, const std::vector<std::string>& slot_ids, string_view context, std::vector<std::vector<uint32_t>>& actions, std::vector<std::vector<float>>& scores)
   {
-    v_array<example*> examples;
+    VW::multi_ex examples;
     examples.push_back(get_or_create_example());
 
     //copy due to destructive parsing by rapidjson


### PR DESCRIPTION
70c6b74cf build: update min cmake version required to 3.10 to reflect dependency changes (#3936)
c396af5dd fix: Add an expectile_q parameter. (#3932)
7b0c65f7e feat: add inline image support to demo (#3933)
911fabba9 refactor: Convert parser usage of v_array<example*> to multi_ex (#3931)