### PR TITLE
Fix CMake configuration + support newer C++ versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,20 @@ endif()
 
 project(reinforcement_learning)
 
-set(CMAKE_CXX_STANDARD 11)
+#set(CMAKE_CXX_STANDARD 11)
+# Add support for building library with latest version of C++ supported by your compiler
+# Copied from VW
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/cmake/")
+option(USE_LATEST_STD "Override using C++11 with the latest standard the compiler offers. Default is C++11. " OFF)
+include(DetectCXXStandard)
+set(RL_CXX_STANDARD 11)
+if(USE_LATEST_STD)
+  DetectCXXStandard(RL_CXX_STANDARD)
+endif()
+message(STATUS "Using C++ standard: " ${RL_CXX_STANDARD})
+set(CMAKE_CXX_STANDARD ${RL_CXX_STANDARD})
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 option(RL_BUILD_PYTHON "Build the Python bindings" OFF)
 option(USE_ZSTD "Whether to enable usage of zstandard compression" ON)

--- a/cmake/DetectCXXStandard.cmake
+++ b/cmake/DetectCXXStandard.cmake
@@ -1,0 +1,35 @@
+include(CheckCXXCompilerFlag)
+
+function(DetectCXXStandard OUTPUT_VAR)
+  if(NOT MSVC)
+    set(CXX_STANDARD20_FLAG "-std=c++20")
+    set(CXX_STANDARD17_FLAG "-std=c++17")
+    set(CXX_STANDARD14_FLAG "-std=c++14")
+    set(CXX_STANDARD11_FLAG "-std=c++11")
+  elseif(MSVC)
+    set(CXX_STANDARD20_FLAG "/std:c++20")
+    set(CXX_STANDARD17_FLAG "/std:c++17")
+    set(CXX_STANDARD14_FLAG "/std:c++14")
+  endif()
+
+  # TODO use VERSION_GREATER_EQUAL in cmake 3.7+
+  check_cxx_compiler_flag(${CXX_STANDARD20_FLAG} HAS_CXX20_FLAG)
+  if (HAS_CXX20_FLAG AND ((${CMAKE_VERSION} VERSION_EQUAL "3.12.0") OR (${CMAKE_VERSION} VERSION_GREATER "3.12.0")))
+    set(${OUTPUT_VAR} 20 PARENT_SCOPE)
+    return()
+  endif()
+
+  check_cxx_compiler_flag(${CXX_STANDARD17_FLAG} HAS_CXX17_FLAG)
+  if (HAS_CXX17_FLAG AND ((${CMAKE_VERSION} VERSION_EQUAL "3.8.0") OR (${CMAKE_VERSION} VERSION_GREATER "3.8.0")))
+    set(${OUTPUT_VAR} 17 PARENT_SCOPE)
+    return()
+  endif()
+
+  check_cxx_compiler_flag(${CXX_STANDARD14_FLAG} HAS_CXX14_FLAG)
+  if (HAS_CXX14_FLAG)
+    set(${OUTPUT_VAR} 14 PARENT_SCOPE)
+    return()
+  endif()
+
+  set(${OUTPUT_VAR} 11 PARENT_SCOPE)
+endfunction()

--- a/ext_libs/fakeit/fakeit/fakeit.hpp
+++ b/ext_libs/fakeit/fakeit/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2017-05-07 09:26:48.645797
+ *  Generated: 2022-06-12 10:26:04.711108
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -34,6 +34,14 @@
 
 
 namespace fakeit {
+
+    template<class...>
+    using fk_void_t = void;
+
+    template <bool...> struct bool_pack;
+
+    template <bool... v>
+    using all_true = std::is_same<bool_pack<true, v...>, bool_pack<v..., true>>;
 
     template<class C>
     struct naked_type {
@@ -250,6 +258,35 @@ namespace fakeit {
 			s += val;
 			s += "'";
 			return s;
+		}
+	};
+
+	template <>
+	struct Formatter<char const*>
+	{
+		static std::string format(char const* const &val)
+		{
+			std::string s;
+			if(val != nullptr)
+			{
+				s += '"';
+				s += val;
+				s += '"';
+			}
+			else
+			{
+				s = "[nullptr]";
+			}
+			return s;
+		}
+	};
+
+	template <>
+	struct Formatter<char*>
+	{
+		static std::string format(char* const &val)
+		{
+			return Formatter<char const*>::format( val );
 		}
 	};
 
@@ -742,6 +779,9 @@ namespace fakeit {
     };
 
 }
+#ifdef FAKEIT_ASSERT_ON_UNEXPECTED_METHOD_INVOCATION
+#include <cassert>
+#endif
 
 namespace fakeit {
 
@@ -752,6 +792,9 @@ namespace fakeit {
         void handle(const UnexpectedMethodCallEvent &e) override {
             fireEvent(e);
             auto &eh = getTestingFrameworkAdapter();
+            #ifdef FAKEIT_ASSERT_ON_UNEXPECTED_METHOD_INVOCATION
+            assert(!"Unexpected method invocation");
+            #endif
             eh.handle(e);
         }
 
@@ -828,7 +871,7 @@ namespace fakeit {
             out << "Unexpected method invocation: ";
             out << e.getInvocation().format() << std::endl;
             if (UnexpectedType::Unmatched == e.getUnexpectedType()) {
-                out << "  Could not find Any recorded behavior to support this method call.";
+                out << "  Could not find any recorded behavior to support this method call.";
             } else {
                 out << "  An unmocked method was invoked. All used virtual methods must be stubbed!";
             }
@@ -865,9 +908,20 @@ namespace fakeit {
         virtual std::string format(const NoMoreInvocationsVerificationEvent &e) override {
             std::ostringstream out;
             out << "Verification error" << std::endl;
-            out << "Expected no more invocations!! But the following unverified invocations were found:" << std::endl;
+            out << "Expected no more invocations!! but the following unverified invocations were found:" << std::endl;
             formatInvocationList(out, e.unverifedIvocations());
             return out.str();
+        }
+
+        static std::string formatExpectedPattern(const std::vector<fakeit::Sequence *> &expectedPattern) {
+            std::string expectedPatternStr;
+            for (unsigned int i = 0; i < expectedPattern.size(); i++) {
+                Sequence *s = expectedPattern[i];
+                expectedPatternStr += formatSequence(*s);
+                if (i < expectedPattern.size() - 1)
+                    expectedPatternStr += " ... ";
+            }
+            return expectedPatternStr;
         }
 
     private:
@@ -901,8 +955,8 @@ namespace fakeit {
 
         static void formatInvocationList(std::ostream &out, const std::vector<fakeit::Invocation *> &actualSequence) {
             size_t max_size = actualSequence.size();
-            if (max_size > 5)
-                max_size = 5;
+            if (max_size > 50)
+                max_size = 50;
 
             for (unsigned int i = 0; i < max_size; i++) {
                 out << "  ";
@@ -935,20 +989,21 @@ namespace fakeit {
             out << " * " << val.getTimes();
             return out.str();
         }
-
-        static std::string formatExpectedPattern(const std::vector<fakeit::Sequence *> &expectedPattern) {
-            std::string expectedPatternStr;
-            for (unsigned int i = 0; i < expectedPattern.size(); i++) {
-                Sequence *s = expectedPattern[i];
-                expectedPatternStr += formatSequence(*s);
-                if (i < expectedPattern.size() - 1)
-                    expectedPatternStr += " ... ";
-            }
-            return expectedPatternStr;
-        }
     };
 }
+#include <exception>
+
+
 namespace fakeit {
+#if __cplusplus >= 201703L || defined(__cpp_lib_uncaught_exceptions)
+    inline bool UncaughtException () {
+        return std::uncaught_exceptions() >= 1;
+    }
+#else
+    inline bool UncaughtException () {
+      return std::uncaught_exception();
+    }
+#endif
 
     struct FakeitException {
         std::exception err;
@@ -1167,11 +1222,13 @@ static fakeit::DefaultFakeit& Fakeit = fakeit::BoostTestFakeit::getInstance();
 #include <unordered_set>
 
 #include <memory>
+#undef max
 #include <functional>
 #include <type_traits>
 #include <vector>
 #include <array>
 #include <new>
+#include <limits>
 
 #include <functional>
 #include <type_traits>
@@ -5195,9 +5252,16 @@ namespace fakeit {
 
     };
 }
+#if defined(__GNUG__) && !defined(__clang__)
+#define FAKEIT_NO_DEVIRTUALIZE_ATTR [[gnu::optimize("no-devirtualize")]]
+#else
+#define FAKEIT_NO_DEVIRTUALIZE_ATTR
+#endif
+
 namespace fakeit {
 
     template<typename TARGET, typename SOURCE>
+    FAKEIT_NO_DEVIRTUALIZE_ATTR
     TARGET union_cast(SOURCE source) {
 
         union {
@@ -5211,18 +5275,27 @@ namespace fakeit {
 }
 
 namespace fakeit {
-    class NoVirtualDtor {
+    class NoVirtualDtor : public std::runtime_error {
+    public:
+		NoVirtualDtor() :std::runtime_error("Can't mock the destructor. No virtual destructor was found") {}
     };
 
     class VTUtils {
     public:
 
+#if defined(__GNUG__) && !defined(__clang__) && __GNUC__ >= 8
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
         template<typename C, typename R, typename ... arglist>
         static unsigned int getOffset(R (C::*vMethod)(arglist...)) {
             auto sMethod = reinterpret_cast<unsigned int (VirtualOffsetSelector::*)(int)>(vMethod);
             VirtualOffsetSelector offsetSelctor;
             return (offsetSelctor.*sMethod)(0);
         }
+#if defined(__GNUG__) && !defined(__clang__) && __GNUC__ >= 8
+#pragma GCC diagnostic pop
+#endif
 
         template<typename C>
         static typename std::enable_if<std::has_virtual_destructor<C>::value, unsigned int>::type
@@ -5237,6 +5310,18 @@ namespace fakeit {
         getDestructorOffset() {
             throw NoVirtualDtor();
         }
+
+		template<typename C>
+		static typename std::enable_if<std::has_virtual_destructor<C>::value, bool>::type
+			hasVirtualDestructor() {
+			return true;
+		}
+
+		template<typename C>
+		static typename std::enable_if<!std::has_virtual_destructor<C>::value, bool>::type
+			hasVirtualDestructor() {
+			return false;
+		}
 
         template<typename C>
         static unsigned int getVTSize() {
@@ -5255,7 +5340,7 @@ namespace fakeit {
 #ifdef _MSC_VER
 namespace fakeit {
 
-    typedef unsigned long DWORD;
+    typedef unsigned long dword_;
 
     struct TypeDescriptor {
         TypeDescriptor() :
@@ -5268,7 +5353,7 @@ namespace fakeit {
         }
 
 		char *ptrToVTable;
-        DWORD spare;
+        dword_ spare;
         char name[8];
     };
 
@@ -5292,9 +5377,9 @@ namespace fakeit {
         }
 
         const std::type_info *pTypeDescriptor;
-        DWORD numContainedBases;
+        dword_ numContainedBases;
         struct PMD where;
-        DWORD attributes;
+        dword_ attributes;
     };
 
     template<typename C, typename... baseclasses>
@@ -5316,9 +5401,9 @@ namespace fakeit {
             delete[] pBaseClassArray;
         }
 
-        DWORD signature;
-        DWORD attributes;
-        DWORD numBaseClasses;
+        dword_ signature;
+        dword_ attributes;
+        dword_ numBaseClasses;
         RTTIBaseClassDescriptor **pBaseClassArray;
 
         template<typename BaseType>
@@ -5349,13 +5434,14 @@ namespace fakeit {
 			signature(0), offset(0), cdOffset(0),
 			typeDescriptorOffset(0), classDescriptorOffset(0)
 		{
+                    (void)unused;
 		}
 
-		DWORD signature;
-		DWORD offset;
-		DWORD cdOffset;
-		DWORD typeDescriptorOffset;
-		DWORD classDescriptorOffset;
+		dword_ signature;
+		dword_ offset;
+		dword_ cdOffset;
+		dword_ typeDescriptorOffset;
+		dword_ classDescriptorOffset;
 #else
 		RTTICompleteObjectLocator(const std::type_info &info) :
 			signature(0), offset(0), cdOffset(0),
@@ -5367,9 +5453,9 @@ namespace fakeit {
 			delete pClassDescriptor;
 		}
 
-		DWORD signature;
-		DWORD offset;
-		DWORD cdOffset;
+		dword_ signature;
+		dword_ offset;
+		dword_ cdOffset;
 		const std::type_info *pTypeDescriptor;
 		struct RTTIClassHierarchyDescriptor<C, baseclasses...> *pClassDescriptor;
 #endif
@@ -5698,73 +5784,78 @@ namespace fakeit {
 }
 #include <new>
 
-namespace fakeit {
 
-#ifdef __GNUG__
-#ifndef __clang__
-#pragma GCC diagnostic ignored "-Wpedantic"
-#endif
-#endif
+namespace fakeit
+{
+    namespace details
+    {
+        template <int instanceAreaSize, typename C, typename... BaseClasses>
+        class FakeObjectImpl
+        {
+        public:
+            void initializeDataMembersArea()
+            {
+                for (size_t i = 0; i < instanceAreaSize; ++i)
+                {
+                    instanceArea[i] = (char) 0;
+                }
+            }
 
+        protected:
+            VirtualTable<C, BaseClasses...> vtable;
+            char instanceArea[instanceAreaSize];
+        };
 
-#ifdef _MSC_VER
-#pragma warning( push )
-#pragma warning( disable : 4200 )
-#endif
+        template <typename C, typename... BaseClasses>
+        class FakeObjectImpl<0, C, BaseClasses...>
+        {
+        public:
+            void initializeDataMembersArea()
+            {}
 
+        protected:
+            VirtualTable<C, BaseClasses...> vtable;
+        };
+    }
 
-    template<typename C, typename ... baseclasses>
-    class FakeObject {
-
-        VirtualTable<C, baseclasses...> vtable;
-
-        static const size_t SIZE = sizeof(C) - sizeof(VirtualTable<C, baseclasses...>);
-        char instanceArea[SIZE ? SIZE : 0];
-
-        FakeObject(FakeObject const &) = delete;
-        FakeObject &operator=(FakeObject const &) = delete;
+    template <typename C, typename... BaseClasses>
+    class FakeObject
+        : public details::FakeObjectImpl<sizeof(C) - sizeof(VirtualTable<C, BaseClasses...>), C, BaseClasses...>
+    {
+        FakeObject(FakeObject const&) = delete;
+        FakeObject& operator=(FakeObject const&) = delete;
 
     public:
-
-        FakeObject() : vtable() {
-            initializeDataMembersArea();
+        FakeObject()
+        {
+            this->initializeDataMembersArea();
         }
 
-        ~FakeObject() {
-            vtable.dispose();
+        ~FakeObject()
+        {
+            this->vtable.dispose();
         }
 
-        void initializeDataMembersArea() {
-            for (size_t i = 0; i < SIZE; ++i) instanceArea[i] = (char) 0;
+        void setMethod(unsigned int index, void* method)
+        {
+            this->vtable.setMethod(index, method);
         }
 
-        void setMethod(unsigned int index, void *method) {
-            vtable.setMethod(index, method);
+        VirtualTable<C, BaseClasses...>& getVirtualTable()
+        {
+            return this->vtable;
         }
 
-        VirtualTable<C, baseclasses...> &getVirtualTable() {
-            return vtable;
+        void setVirtualTable(VirtualTable<C, BaseClasses...>& t)
+        {
+            this->vtable = t;
         }
 
-        void setVirtualTable(VirtualTable<C, baseclasses...> &t) {
-            vtable = t;
-        }
-
-        void setDtor(void *dtor) {
-            vtable.setDtor(dtor);
+        void setDtor(void* dtor)
+        {
+            this->vtable.setDtor(dtor);
         }
     };
-
-#ifdef _MSC_VER
-#pragma warning( pop )
-#endif
-
-#ifdef __GNUG__
-#ifndef __clang__
-#pragma GCC diagnostic pop
-#endif
-#endif
-
 }
 namespace fakeit {
 
@@ -5865,6 +5956,10 @@ namespace fakeit {
                 std::vector<std::shared_ptr<Destructible>> &methodMocks,
                 std::vector<unsigned int> &offsets) :
                 _methodMocks(methodMocks), _offsets(offsets) {
+			for (std::vector<unsigned int>::iterator it = _offsets.begin(); it != _offsets.end(); ++it)
+			{
+				*it = std::numeric_limits<int>::max();
+			}
         }
 
         Destructible *getInvocatoinHandlerPtrById(unsigned int id) override {
@@ -6062,31 +6157,31 @@ namespace fakeit {
 
     template<int N>
     struct apply_func {
-        template<typename R, typename ... ArgsF, typename ... ArgsT, typename ... Args>
-        static R applyTuple(std::function<R(ArgsF &...)> f, std::tuple<ArgsT...> &t, Args &... args) {
-            return apply_func<N - 1>::template applyTuple(f, t, std::get<N - 1>(t), args...);
+        template<typename R, typename ... ArgsF, typename ... ArgsT, typename ... Args, typename FunctionType>
+        static R applyTuple(FunctionType&& f, std::tuple<ArgsT...> &t, Args &... args) {
+            return apply_func<N - 1>::template applyTuple<R>(std::forward<FunctionType>(f), t, std::get<N - 1>(t), args...);
         }
     };
 
     template<>
     struct apply_func < 0 > {
-        template<typename R, typename ... ArgsF, typename ... ArgsT, typename ... Args>
-        static R applyTuple(std::function<R(ArgsF &...)> f, std::tuple<ArgsT...> & , Args &... args) {
-            return f(args...);
+        template<typename R, typename ... ArgsF, typename ... ArgsT, typename ... Args, typename FunctionType>
+        static R applyTuple(FunctionType&& f, std::tuple<ArgsT...> & , Args &... args) {
+            return std::forward<FunctionType>(f)(args...);
         }
     };
 
     struct TupleDispatcher {
 
-        template<typename R, typename ... ArgsF, typename ... ArgsT>
-        static R applyTuple(std::function<R(ArgsF &...)> f, std::tuple<ArgsT...> &t) {
-            return apply_func<sizeof...(ArgsT)>::template applyTuple(f, t);
+        template<typename R, typename ... ArgsF, typename ... ArgsT, typename FunctionType>
+        static R applyTuple(FunctionType&& f, std::tuple<ArgsT...> &t) {
+            return apply_func<sizeof...(ArgsT)>::template applyTuple<R>(std::forward<FunctionType>(f), t);
         }
 
-        template<typename R, typename ...arglist>
-        static R invoke(std::function<R(arglist &...)> func, const std::tuple<arglist...> &arguments) {
+        template<typename R, typename ...arglist, typename FunctionType>
+        static R invoke(FunctionType&& func, const std::tuple<arglist...> &arguments) {
             std::tuple<arglist...> &args = const_cast<std::tuple<arglist...> &>(arguments);
-            return applyTuple(func, args);
+            return applyTuple<R>(std::forward<FunctionType>(func), args);
         }
 
         template<typename TupleType, typename FunctionType>
@@ -6277,6 +6372,10 @@ namespace fakeit {
     };
 
 }
+#include <cmath>
+#include <cstring>
+
+
 namespace fakeit {
 
     struct IMatcher : Destructible {
@@ -6284,281 +6383,584 @@ namespace fakeit {
         virtual std::string format() const = 0;
     };
 
-    template<typename T>
+    template<typename ActualT>
     struct TypedMatcher : IMatcher {
-        virtual bool matches(const T &actual) const = 0;
+        virtual bool matches(const ActualT &actual) const = 0;
     };
 
-    template<typename T>
-    struct TypedMatcherCreator {
+    template<typename ExpectedTRef>
+    struct ComparisonMatcherCreatorBase {
+        using ExpectedT = typename naked_type<ExpectedTRef>::type;
 
-        virtual ~TypedMatcherCreator() = default;
+        ExpectedTRef _expectedRef;
 
-        virtual TypedMatcher<T> *createMatcher() const = 0;
-    };
-
-    template<typename T>
-    struct ComparisonMatcherCreator : public TypedMatcherCreator<T> {
-
-        virtual ~ComparisonMatcherCreator() = default;
-
-        ComparisonMatcherCreator(const T &arg)
-                : _expected(arg) {
+        template <typename T>
+        ComparisonMatcherCreatorBase(T &&expectedRef)
+                : _expectedRef(std::forward<T>(expectedRef)) {
         }
 
-        struct Matcher : public TypedMatcher<T> {
-            Matcher(const T &expected)
-                    : _expected(expected) {
-            }
+        template <typename ActualT, typename = ExpectedT, typename = void>
+        struct MatcherBase : public TypedMatcher<ActualT> {
+            const ExpectedT _expected;
 
-            const T _expected;
+            MatcherBase(ExpectedTRef expected)
+                    : _expected{std::forward<ExpectedTRef>(expected)} {
+            }
         };
 
-        const T &_expected;
+        template <typename ActualT, typename U>
+        struct MatcherBase<ActualT, U, typename std::enable_if<std::is_same<U, ExpectedT>::value && std::is_array<U>::value>::type> : public TypedMatcher<ActualT> {
+            ExpectedT _expected;
+
+            MatcherBase(ExpectedTRef expected) {
+                std::memcpy(_expected, expected, sizeof(_expected));
+            }
+        };
     };
 
     namespace internal {
-        template<typename T>
-        struct TypedAnyMatcher : public TypedMatcherCreator<T> {
+        struct AnyMatcherCreator{
+            template <typename ActualT>
+            struct IsTypeCompatible : std::true_type {};
 
-            virtual ~TypedAnyMatcher() = default;
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public TypedMatcher<ActualT> {
+                    bool matches(const ActualT &) const override {
+                        return true;
+                    }
 
-            TypedAnyMatcher() {
-            }
+                    std::string format() const override {
+                        return "Any";
+                    }
+                };
 
-            struct Matcher : public TypedMatcher<T> {
-                virtual bool matches(const T &) const override {
-                    return true;
-                }
-
-                virtual std::string format() const override {
-                    return "Any";
-                }
-            };
-
-            virtual TypedMatcher<T> *createMatcher() const override {
                 return new Matcher();
             }
-
         };
 
-        template<typename T>
-        struct EqMatcherCreator : public ComparisonMatcherCreator<T> {
+        template<typename ExpectedTRef>
+        struct EqMatcherCreator : public ComparisonMatcherCreatorBase<ExpectedTRef> {
+            using ExpectedT = typename ComparisonMatcherCreatorBase<ExpectedTRef>::ExpectedT;
 
-            virtual ~EqMatcherCreator() = default;
+            template <typename ActualT, typename = void>
+            struct IsTypeCompatible : std::false_type {};
 
-            EqMatcherCreator(const T &expected)
-                    : ComparisonMatcherCreator<T>(expected) {
-            }
+            template <typename ActualT>
+            struct IsTypeCompatible<ActualT, fk_void_t<decltype(std::declval<ActualT>() == std::declval<ExpectedT>())>> : std::true_type {};
 
-            struct Matcher : public ComparisonMatcherCreator<T>::Matcher {
-                Matcher(const T &expected)
-                        : ComparisonMatcherCreator<T>::Matcher(expected) {
-                }
+            using ComparisonMatcherCreatorBase<ExpectedTRef>::ComparisonMatcherCreatorBase;
 
-                virtual std::string format() const override {
-                    return TypeFormatter<T>::format(this->_expected);
-                }
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT> {
+                    using ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT>::MatcherBase;
 
-                virtual bool matches(const T &actual) const override {
-                    return actual == this->_expected;
-                }
-            };
+                    virtual std::string format() const override {
+                        return TypeFormatter<ExpectedT>::format(this->_expected);
+                    }
 
-            virtual TypedMatcher<T> *createMatcher() const {
-                return new Matcher(this->_expected);
-            }
+                    virtual bool matches(const ActualT &actual) const override {
+                        return actual == this->_expected;
+                    }
+                };
 
-        };
-
-        template<typename T>
-        struct GtMatcherCreator : public ComparisonMatcherCreator<T> {
-
-            virtual ~GtMatcherCreator() = default;
-
-            GtMatcherCreator(const T &expected)
-                    : ComparisonMatcherCreator<T>(expected) {
-            }
-
-            struct Matcher : public ComparisonMatcherCreator<T>::Matcher {
-                Matcher(const T &expected)
-                        : ComparisonMatcherCreator<T>::Matcher(expected) {
-                }
-
-                virtual bool matches(const T &actual) const override {
-                    return actual > this->_expected;
-                }
-
-                virtual std::string format() const override {
-                    return std::string(">") + TypeFormatter<T>::format(this->_expected);
-                }
-            };
-
-            virtual TypedMatcher<T> *createMatcher() const override {
-                return new Matcher(this->_expected);
+                return new Matcher(std::forward<ExpectedTRef>(this->_expectedRef));
             }
         };
 
-        template<typename T>
-        struct GeMatcherCreator : public ComparisonMatcherCreator<T> {
+        template<typename ExpectedTRef>
+        struct GtMatcherCreator : public ComparisonMatcherCreatorBase<ExpectedTRef> {
+            using ExpectedT = typename ComparisonMatcherCreatorBase<ExpectedTRef>::ExpectedT;
 
-            virtual ~GeMatcherCreator() = default;
+            template <typename ActualT, typename = void>
+            struct IsTypeCompatible : std::false_type {};
 
-            GeMatcherCreator(const T &expected)
-                    : ComparisonMatcherCreator<T>(expected) {
-            }
+            template <typename ActualT>
+            struct IsTypeCompatible<ActualT, fk_void_t<decltype(std::declval<ActualT>() > std::declval<ExpectedT>())>> : std::true_type {};
 
-            struct Matcher : public ComparisonMatcherCreator<T>::Matcher {
-                Matcher(const T &expected)
-                        : ComparisonMatcherCreator<T>::Matcher(expected) {
-                }
+            using ComparisonMatcherCreatorBase<ExpectedTRef>::ComparisonMatcherCreatorBase;
 
-                virtual bool matches(const T &actual) const override {
-                    return actual >= this->_expected;
-                }
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT> {
+                    using ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT>::MatcherBase;
 
-                virtual std::string format() const override {
-                    return std::string(">=") + TypeFormatter<T>::format(this->_expected);
-                }
-            };
+                    virtual std::string format() const override {
+                        return std::string(">") + TypeFormatter<ExpectedT>::format(this->_expected);
+                    }
 
-            virtual TypedMatcher<T> *createMatcher() const override {
-                return new Matcher(this->_expected);
+                    virtual bool matches(const ActualT &actual) const override {
+                        return actual > this->_expected;
+                    }
+                };
+
+                return new Matcher(std::forward<ExpectedTRef>(this->_expectedRef));
             }
         };
 
-        template<typename T>
-        struct LtMatcherCreator : public ComparisonMatcherCreator<T> {
+        template<typename ExpectedTRef>
+        struct GeMatcherCreator : public ComparisonMatcherCreatorBase<ExpectedTRef> {
+            using ExpectedT = typename ComparisonMatcherCreatorBase<ExpectedTRef>::ExpectedT;
 
-            virtual ~LtMatcherCreator() = default;
+            template <typename ActualT, typename = void>
+            struct IsTypeCompatible : std::false_type {};
 
-            LtMatcherCreator(const T &expected)
-                    : ComparisonMatcherCreator<T>(expected) {
+            template <typename ActualT>
+            struct IsTypeCompatible<ActualT, fk_void_t<decltype(std::declval<ActualT>() >= std::declval<ExpectedT>())>> : std::true_type {};
+
+            using ComparisonMatcherCreatorBase<ExpectedTRef>::ComparisonMatcherCreatorBase;
+
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT> {
+                    using ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT>::MatcherBase;
+
+                    virtual std::string format() const override {
+                        return std::string(">=") + TypeFormatter<ExpectedT>::format(this->_expected);
+                    }
+
+                    virtual bool matches(const ActualT &actual) const override {
+                        return actual >= this->_expected;
+                    }
+                };
+
+                return new Matcher(std::forward<ExpectedTRef>(this->_expectedRef));
             }
-
-            struct Matcher : public ComparisonMatcherCreator<T>::Matcher {
-                Matcher(const T &expected)
-                        : ComparisonMatcherCreator<T>::Matcher(expected) {
-                }
-
-                virtual bool matches(const T &actual) const override {
-                    return actual < this->_expected;
-                }
-
-                virtual std::string format() const override {
-                    return std::string("<") + TypeFormatter<T>::format(this->_expected);
-                }
-            };
-
-            virtual TypedMatcher<T> *createMatcher() const override {
-                return new Matcher(this->_expected);
-            }
-
         };
 
-        template<typename T>
-        struct LeMatcherCreator : public ComparisonMatcherCreator<T> {
+        template<typename ExpectedTRef>
+        struct LtMatcherCreator : public ComparisonMatcherCreatorBase<ExpectedTRef> {
+            using ExpectedT = typename ComparisonMatcherCreatorBase<ExpectedTRef>::ExpectedT;
 
-            virtual ~LeMatcherCreator() = default;
+            template <typename ActualT, typename = void>
+            struct IsTypeCompatible : std::false_type {};
 
-            LeMatcherCreator(const T &expected)
-                    : ComparisonMatcherCreator<T>(expected) {
+            template <typename ActualT>
+            struct IsTypeCompatible<ActualT, fk_void_t<decltype(std::declval<ActualT>() < std::declval<ExpectedT>())>> : std::true_type {};
+
+            using ComparisonMatcherCreatorBase<ExpectedTRef>::ComparisonMatcherCreatorBase;
+
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT> {
+                    using ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT>::MatcherBase;
+
+                    virtual std::string format() const override {
+                        return std::string("<") + TypeFormatter<ExpectedT>::format(this->_expected);
+                    }
+
+                    virtual bool matches(const ActualT &actual) const override {
+                        return actual < this->_expected;
+                    }
+                };
+
+                return new Matcher(std::forward<ExpectedTRef>(this->_expectedRef));
             }
-
-            struct Matcher : public ComparisonMatcherCreator<T>::Matcher {
-                Matcher(const T &expected)
-                        : ComparisonMatcherCreator<T>::Matcher(expected) {
-                }
-
-                virtual bool matches(const T &actual) const override {
-                    return actual <= this->_expected;
-                }
-
-                virtual std::string format() const override {
-                    return std::string("<=") + TypeFormatter<T>::format(this->_expected);
-                }
-            };
-
-            virtual TypedMatcher<T> *createMatcher() const override {
-                return new Matcher(this->_expected);
-            }
-
         };
 
-        template<typename T>
-        struct NeMatcherCreator : public ComparisonMatcherCreator<T> {
+        template<typename ExpectedTRef>
+        struct LeMatcherCreator : public ComparisonMatcherCreatorBase<ExpectedTRef> {
+            using ExpectedT = typename ComparisonMatcherCreatorBase<ExpectedTRef>::ExpectedT;
 
-            virtual ~NeMatcherCreator() = default;
+            template <typename ActualT, typename = void>
+            struct IsTypeCompatible : std::false_type {};
 
-            NeMatcherCreator(const T &expected)
-                    : ComparisonMatcherCreator<T>(expected) {
+            template <typename ActualT>
+            struct IsTypeCompatible<ActualT, fk_void_t<decltype(std::declval<ActualT>() <= std::declval<ExpectedT>())>> : std::true_type {};
+
+            using ComparisonMatcherCreatorBase<ExpectedTRef>::ComparisonMatcherCreatorBase;
+
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT> {
+                    using ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT>::MatcherBase;
+
+                    virtual std::string format() const override {
+                        return std::string("<=") + TypeFormatter<ExpectedT>::format(this->_expected);
+                    }
+
+                    virtual bool matches(const ActualT &actual) const override {
+                        return actual <= this->_expected;
+                    }
+                };
+
+                return new Matcher(std::forward<ExpectedTRef>(this->_expectedRef));
+            }
+        };
+
+        template<typename ExpectedTRef>
+        struct NeMatcherCreator : public ComparisonMatcherCreatorBase<ExpectedTRef> {
+            using ExpectedT = typename ComparisonMatcherCreatorBase<ExpectedTRef>::ExpectedT;
+
+            template <typename ActualT, typename = void>
+            struct IsTypeCompatible : std::false_type {};
+
+            template <typename ActualT>
+            struct IsTypeCompatible<ActualT, fk_void_t<decltype(std::declval<ActualT>() != std::declval<ExpectedT>())>> : std::true_type {};
+
+            using ComparisonMatcherCreatorBase<ExpectedTRef>::ComparisonMatcherCreatorBase;
+
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT> {
+                    using ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT>::MatcherBase;
+
+                    virtual std::string format() const override {
+                        return std::string("!=") + TypeFormatter<ExpectedT>::format(this->_expected);
+                    }
+
+                    virtual bool matches(const ActualT &actual) const override {
+                        return actual != this->_expected;
+                    }
+                };
+
+                return new Matcher(std::forward<ExpectedTRef>(this->_expectedRef));
+            }
+        };
+
+        template <typename ExpectedTRef>
+        struct StrEqMatcherCreator : public ComparisonMatcherCreatorBase<ExpectedTRef> {
+            using ExpectedT = typename ComparisonMatcherCreatorBase<ExpectedTRef>::ExpectedT;
+
+            template <typename ActualT, typename = void>
+            struct IsTypeCompatible : std::false_type {};
+
+            template <typename ActualT>
+            struct IsTypeCompatible<ActualT, fk_void_t<decltype(strcmp(std::declval<ActualT>(), std::declval<const char*>()))>> : std::true_type {};
+
+            using ComparisonMatcherCreatorBase<ExpectedTRef>::ComparisonMatcherCreatorBase;
+
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT> {
+                    using ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT>::MatcherBase;
+
+                    virtual std::string format() const override {
+                        return TypeFormatter<ExpectedT>::format(this->_expected);
+                    }
+
+                    virtual bool matches(const ActualT &actual) const override {
+                        return std::strcmp(actual, this->_expected.c_str()) == 0;
+                    }
+                };
+
+                return new Matcher(std::forward<ExpectedTRef>(this->_expectedRef));
+            }
+        };
+
+        template <typename ExpectedTRef>
+        struct StrGtMatcherCreator : public ComparisonMatcherCreatorBase<ExpectedTRef> {
+            using ExpectedT = typename ComparisonMatcherCreatorBase<ExpectedTRef>::ExpectedT;
+
+            template <typename ActualT, typename = void>
+            struct IsTypeCompatible : std::false_type {};
+
+            template <typename ActualT>
+            struct IsTypeCompatible<ActualT, fk_void_t<decltype(strcmp(std::declval<ActualT>(), std::declval<const char*>()))>> : std::true_type {};
+
+            using ComparisonMatcherCreatorBase<ExpectedTRef>::ComparisonMatcherCreatorBase;
+
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT> {
+                    using ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT>::MatcherBase;
+
+                    virtual std::string format() const override {
+                        return std::string(">") + TypeFormatter<ExpectedT>::format(this->_expected);
+                    }
+
+                    virtual bool matches(const ActualT &actual) const override {
+                        return std::strcmp(actual, this->_expected.c_str()) > 0;
+                    }
+                };
+
+                return new Matcher(std::forward<ExpectedTRef>(this->_expectedRef));
+            }
+        };
+
+        template <typename ExpectedTRef>
+        struct StrGeMatcherCreator : public ComparisonMatcherCreatorBase<ExpectedTRef> {
+            using ExpectedT = typename ComparisonMatcherCreatorBase<ExpectedTRef>::ExpectedT;
+
+            template <typename ActualT, typename = void>
+            struct IsTypeCompatible : std::false_type {};
+
+            template <typename ActualT>
+            struct IsTypeCompatible<ActualT, fk_void_t<decltype(strcmp(std::declval<ActualT>(), std::declval<const char*>()))>> : std::true_type {};
+
+            using ComparisonMatcherCreatorBase<ExpectedTRef>::ComparisonMatcherCreatorBase;
+
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT> {
+                    using ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT>::MatcherBase;
+
+                    virtual std::string format() const override {
+                        return std::string(">=") + TypeFormatter<ExpectedT>::format(this->_expected);
+                    }
+
+                    virtual bool matches(const ActualT &actual) const override {
+                        return std::strcmp(actual, this->_expected.c_str()) >= 0;
+                    }
+                };
+
+                return new Matcher(std::forward<ExpectedTRef>(this->_expectedRef));
+            }
+        };
+
+        template <typename ExpectedTRef>
+        struct StrLtMatcherCreator : public ComparisonMatcherCreatorBase<ExpectedTRef> {
+            using ExpectedT = typename ComparisonMatcherCreatorBase<ExpectedTRef>::ExpectedT;
+
+            template <typename ActualT, typename = void>
+            struct IsTypeCompatible : std::false_type {};
+
+            template <typename ActualT>
+            struct IsTypeCompatible<ActualT, fk_void_t<decltype(strcmp(std::declval<ActualT>(), std::declval<const char*>()))>> : std::true_type {};
+
+            using ComparisonMatcherCreatorBase<ExpectedTRef>::ComparisonMatcherCreatorBase;
+
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT> {
+                    using ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT>::MatcherBase;
+
+                    virtual std::string format() const override {
+                        return std::string("<") + TypeFormatter<ExpectedT>::format(this->_expected);
+                    }
+
+                    virtual bool matches(const ActualT &actual) const override {
+                        return std::strcmp(actual, this->_expected.c_str()) < 0;
+                    }
+                };
+
+                return new Matcher(std::forward<ExpectedTRef>(this->_expectedRef));
+            }
+        };
+
+        template <typename ExpectedTRef>
+        struct StrLeMatcherCreator : public ComparisonMatcherCreatorBase<ExpectedTRef> {
+            using ExpectedT = typename ComparisonMatcherCreatorBase<ExpectedTRef>::ExpectedT;
+
+            template <typename ActualT, typename = void>
+            struct IsTypeCompatible : std::false_type {};
+
+            template <typename ActualT>
+            struct IsTypeCompatible<ActualT, fk_void_t<decltype(strcmp(std::declval<ActualT>(), std::declval<const char*>()))>> : std::true_type {};
+
+            using ComparisonMatcherCreatorBase<ExpectedTRef>::ComparisonMatcherCreatorBase;
+
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT> {
+                    using ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT>::MatcherBase;
+
+                    virtual std::string format() const override {
+                        return std::string("<=") + TypeFormatter<ExpectedT>::format(this->_expected);
+                    }
+
+                    virtual bool matches(const ActualT &actual) const override {
+                        return std::strcmp(actual, this->_expected.c_str()) <= 0;
+                    }
+                };
+
+                return new Matcher(std::forward<ExpectedTRef>(this->_expectedRef));
+            }
+        };
+
+        template <typename ExpectedTRef>
+        struct StrNeMatcherCreator : public ComparisonMatcherCreatorBase<ExpectedTRef> {
+            using ExpectedT = typename ComparisonMatcherCreatorBase<ExpectedTRef>::ExpectedT;
+
+            template <typename ActualT, typename = void>
+            struct IsTypeCompatible : std::false_type {};
+
+            template <typename ActualT>
+            struct IsTypeCompatible<ActualT, fk_void_t<decltype(strcmp(std::declval<ActualT>(), std::declval<const char*>()))>> : std::true_type {};
+
+            using ComparisonMatcherCreatorBase<ExpectedTRef>::ComparisonMatcherCreatorBase;
+
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT> {
+                    using ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT>::MatcherBase;
+
+                    virtual std::string format() const override {
+                        return std::string("!=") + TypeFormatter<ExpectedT>::format(this->_expected);
+                    }
+
+                    virtual bool matches(const ActualT &actual) const override {
+                        return std::strcmp(actual, this->_expected.c_str()) != 0;
+                    }
+                };
+
+                return new Matcher(std::forward<ExpectedTRef>(this->_expectedRef));
+            }
+        };
+
+        template<typename ExpectedTRef, typename ExpectedMarginTRef>
+        struct ApproxEqCreator {
+            using ExpectedT = typename naked_type<ExpectedTRef>::type;
+            using ExpectedMarginT = typename naked_type<ExpectedMarginTRef>::type;
+
+            template <typename ActualT, typename = void>
+            struct IsTypeCompatible : std::false_type {};
+
+            template <typename ActualT>
+            struct IsTypeCompatible<ActualT, fk_void_t<decltype(std::abs(std::declval<ActualT>() - std::declval<ExpectedT>()) <= std::declval<ExpectedMarginT>())>> : std::true_type {};
+
+            ExpectedTRef _expectedRef;
+            ExpectedMarginTRef _expectedMarginRef;
+
+            template <typename T, typename U>
+            ApproxEqCreator(T &&expectedRef, U &&expectedMarginRef)
+                    : _expectedRef(std::forward<T>(expectedRef))
+                    , _expectedMarginRef(std::forward<U>(expectedMarginRef)) {
             }
 
-            struct Matcher : public ComparisonMatcherCreator<T>::Matcher {
-                Matcher(const T &expected)
-                        : ComparisonMatcherCreator<T>::Matcher(expected) {
-                }
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public TypedMatcher<ActualT> {
+                    const ExpectedT _expected;
+                    const ExpectedMarginT _expectedMargin;
 
-                virtual bool matches(const T &actual) const override {
-                    return actual != this->_expected;
-                }
+                    Matcher(ExpectedTRef expected, ExpectedMarginTRef expectedMargin)
+                            : _expected{std::forward<ExpectedTRef>(expected)}
+                            , _expectedMargin{std::forward<ExpectedMarginTRef>(expectedMargin)} {
+                    }
 
-                virtual std::string format() const override {
-                    return std::string("!=") + TypeFormatter<T>::format(this->_expected);
-                }
+                    virtual std::string format() const override {
+                        return TypeFormatter<ExpectedT>::format(this->_expected) + std::string("+/-") + TypeFormatter<ExpectedMarginT>::format(this->_expectedMargin);
+                    }
 
-            };
+                    virtual bool matches(const ActualT &actual) const override {
+                        return std::abs(actual - this->_expected) <= this->_expectedMargin;
+                    }
+                };
 
-            virtual TypedMatcher<T> *createMatcher() const override {
-                return new Matcher(this->_expected);
+                return new Matcher(std::forward<ExpectedTRef>(this->_expectedRef), std::forward<ExpectedMarginTRef>(this->_expectedMarginRef));
             }
-
         };
     }
 
     struct AnyMatcher {
     } static _;
 
-    template<typename T>
-    internal::TypedAnyMatcher<T> Any() {
-        internal::TypedAnyMatcher<T> rv;
-        return rv;
+    template <typename T>
+    internal::AnyMatcherCreator Any() {
+        static_assert(sizeof(T) >= 0, "To maintain backward compatibility, this function takes an useless template argument.");
+        internal::AnyMatcherCreator mc;
+        return mc;
+    }
+
+    inline internal::AnyMatcherCreator Any() {
+        internal::AnyMatcherCreator mc;
+        return mc;
     }
 
     template<typename T>
-    internal::EqMatcherCreator<T> Eq(const T &arg) {
-        internal::EqMatcherCreator<T> rv(arg);
-        return rv;
+    internal::EqMatcherCreator<T&&> Eq(T &&arg) {
+        internal::EqMatcherCreator<T&&> mc(std::forward<T>(arg));
+        return mc;
     }
 
     template<typename T>
-    internal::GtMatcherCreator<T> Gt(const T &arg) {
-        internal::GtMatcherCreator<T> rv(arg);
-        return rv;
+    internal::GtMatcherCreator<T&&> Gt(T &&arg) {
+        internal::GtMatcherCreator<T&&> mc(std::forward<T>(arg));
+        return mc;
     }
 
     template<typename T>
-    internal::GeMatcherCreator<T> Ge(const T &arg) {
-        internal::GeMatcherCreator<T> rv(arg);
-        return rv;
+    internal::GeMatcherCreator<T&&> Ge(T &&arg) {
+        internal::GeMatcherCreator<T&&> mc(std::forward<T>(arg));
+        return mc;
     }
 
     template<typename T>
-    internal::LtMatcherCreator<T> Lt(const T &arg) {
-        internal::LtMatcherCreator<T> rv(arg);
-        return rv;
+    internal::LtMatcherCreator<T&&> Lt(T &&arg) {
+        internal::LtMatcherCreator<T&&> mc(std::forward<T>(arg));
+        return mc;
     }
 
     template<typename T>
-    internal::LeMatcherCreator<T> Le(const T &arg) {
-        internal::LeMatcherCreator<T> rv(arg);
-        return rv;
+    internal::LeMatcherCreator<T&&> Le(T &&arg) {
+        internal::LeMatcherCreator<T&&> mc(std::forward<T>(arg));
+        return mc;
     }
 
     template<typename T>
-    internal::NeMatcherCreator<T> Ne(const T &arg) {
-        internal::NeMatcherCreator<T> rv(arg);
-        return rv;
+    internal::NeMatcherCreator<T&&> Ne(T &&arg) {
+        internal::NeMatcherCreator<T&&> mc(std::forward<T>(arg));
+        return mc;
+    }
+
+    inline internal::StrEqMatcherCreator<std::string&&> StrEq(std::string&& arg) {
+        internal::StrEqMatcherCreator<std::string&&> mc(std::move(arg));
+        return mc;
+    }
+
+    inline internal::StrEqMatcherCreator<const std::string&> StrEq(const std::string& arg) {
+        internal::StrEqMatcherCreator<const std::string&> mc(arg);
+        return mc;
+    }
+
+    inline internal::StrGtMatcherCreator<std::string&&> StrGt(std::string&& arg) {
+        internal::StrGtMatcherCreator<std::string&&> mc(std::move(arg));
+        return mc;
+    }
+
+    inline internal::StrGtMatcherCreator<const std::string&> StrGt(const std::string& arg) {
+        internal::StrGtMatcherCreator<const std::string&> mc(arg);
+        return mc;
+    }
+
+    inline internal::StrGeMatcherCreator<std::string&&> StrGe(std::string&& arg) {
+        internal::StrGeMatcherCreator<std::string&&> mc(std::move(arg));
+        return mc;
+    }
+
+    inline internal::StrGeMatcherCreator<const std::string&> StrGe(const std::string& arg) {
+        internal::StrGeMatcherCreator<const std::string&> mc(arg);
+        return mc;
+    }
+
+    inline internal::StrLtMatcherCreator<std::string&&> StrLt(std::string&& arg) {
+        internal::StrLtMatcherCreator<std::string&&> mc(std::move(arg));
+        return mc;
+    }
+
+    inline internal::StrLtMatcherCreator<const std::string&> StrLt(const std::string& arg) {
+        internal::StrLtMatcherCreator<const std::string&> mc(arg);
+        return mc;
+    }
+
+    inline internal::StrLeMatcherCreator<std::string&&> StrLe(std::string&& arg) {
+        internal::StrLeMatcherCreator<std::string&&> mc(std::move(arg));
+        return mc;
+    }
+
+    inline internal::StrLeMatcherCreator<const std::string&> StrLe(const std::string& arg) {
+        internal::StrLeMatcherCreator<const std::string&> mc(arg);
+        return mc;
+    }
+
+    inline internal::StrNeMatcherCreator<std::string&&> StrNe(std::string&& arg) {
+        internal::StrNeMatcherCreator<std::string&&> mc(std::move(arg));
+        return mc;
+    }
+
+    inline internal::StrNeMatcherCreator<const std::string&> StrNe(const std::string& arg) {
+        internal::StrNeMatcherCreator<const std::string&> mc(arg);
+        return mc;
+    }
+
+    template<typename T, typename U,
+        typename std::enable_if<std::is_arithmetic<typename naked_type<T>::type>::value, int>::type = 0,
+        typename std::enable_if<std::is_arithmetic<typename naked_type<U>::type>::value, int>::type = 0>
+    internal::ApproxEqCreator<T&&, U&&> ApproxEq(T &&expected, U &&margin) {
+        internal::ApproxEqCreator<T&&, U&&> mc(std::forward<T>(expected), std::forward<U>(margin));
+        return mc;
     }
 
 }
@@ -6663,7 +7065,7 @@ namespace fakeit {
     struct UserDefinedInvocationMatcher : ActualInvocation<arglist...>::Matcher {
         virtual ~UserDefinedInvocationMatcher() = default;
 
-        UserDefinedInvocationMatcher(std::function<bool(arglist &...)> match)
+        UserDefinedInvocationMatcher(const std::function<bool(arglist &...)>& match)
                 : matcher{match} {
         }
 
@@ -6906,7 +7308,7 @@ namespace fakeit {
     template<int q>
     struct Times : public Quantity {
 
-        Times<q>() : Quantity(q) { }
+        Times() : Quantity(q) { }
 
         template<typename R>
         static Quantifier<R> of(const R &value) {
@@ -7037,6 +7439,24 @@ namespace fakeit {
 
 namespace fakeit {
 
+    namespace helper
+    {
+        template <typename T, int N>
+        struct ArgValue;
+
+        template <int max_index, int tuple_index>
+        struct ArgValidator;
+
+        template<int arg_index, typename current_arg, typename ...T, int ...N, typename ... arglist>
+        static void
+        Assign(std::tuple<ArgValue<T, N>...> arg_vals, current_arg &&p, arglist &&... args);
+
+        template<int N>
+        struct ParamWalker;
+
+    }
+
+
     template<typename R, typename ... arglist>
     struct MethodStubbingProgress {
 
@@ -7116,6 +7536,19 @@ namespace fakeit {
             return AlwaysDo([e](const typename fakeit::test_arg<arglist>::type...) -> R { throw e; });
         }
 
+        template<typename ... valuelist>
+        MethodStubbingProgress<R, arglist...> &
+        ReturnAndSet(R &&r, valuelist &&... arg_vals) {
+            return Do(GetAssigner(std::forward<R>(r),
+                    std::forward<valuelist>(arg_vals)...));
+        }
+
+        template<typename ... valuelist>
+        void AlwaysReturnAndSet(R &&r, valuelist &&... arg_vals) {
+            AlwaysDo(GetAssigner(std::forward<R>(r),
+                std::forward<valuelist>(arg_vals)...));
+        }
+
         virtual MethodStubbingProgress<R, arglist...> &
             Do(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
             return DoImpl(new Repeat<R, arglist...>(method));
@@ -7144,6 +7577,59 @@ namespace fakeit {
 
     private:
         MethodStubbingProgress &operator=(const MethodStubbingProgress &other) = delete;
+
+        template<typename ... valuelist>
+#if __cplusplus >= 201402L
+        auto
+#else
+        std::function<R (typename fakeit::test_arg<arglist>::type...)>
+#endif
+        GetAssigner(R &&r, valuelist &&... arg_vals) {
+            class Lambda {
+            public:
+                Lambda(R &&r, valuelist &&... arg_vals)
+                    : vals_tuple{std::forward<R>(r), std::forward<valuelist>(arg_vals)...} {}
+
+                R operator()(typename fakeit::test_arg<arglist>::type... args) {
+                    helper::ParamWalker<sizeof...(valuelist)>::Assign(vals_tuple,
+                        std::forward<arglist>(args)...);
+                    return std::get<0>(vals_tuple);
+                }
+
+            private:
+                ArgumentsTuple<R, valuelist...> vals_tuple;
+            };
+
+            return Lambda(std::forward<R>(r), std::forward<valuelist>(arg_vals)...);
+        }
+
+        template<typename ...T, int ...N>
+#if __cplusplus >= 201402L
+        auto
+#else
+        std::function<R (typename fakeit::test_arg<arglist>::type...)>
+#endif
+        GetAssigner(R &&r, helper::ArgValue<T, N>... arg_vals) {
+            class Lambda {
+            public:
+                Lambda(R &&r, helper::ArgValue<T, N>... arg_vals)
+                    : ret{std::forward<R>(r)}
+                    , vals_tuple{std::forward<helper::ArgValue<T, N>>(arg_vals)...} {}
+
+                R operator()(typename fakeit::test_arg<arglist>::type... args) {
+                    helper::ArgValidator<sizeof...(arglist), sizeof...(T) - 1>::CheckPositions(vals_tuple);
+                    helper::Assign<1>(vals_tuple, std::forward<arglist>(args)...);
+                    return std::get<0>(ret);
+                }
+
+            private:
+                std::tuple<R> ret;
+                ArgumentsTuple<helper::ArgValue<T, N>...> vals_tuple;
+            };
+
+            return Lambda(std::forward<R>(r), std::forward<helper::ArgValue<T, N>>(arg_vals)...);
+        }
+
     };
 
 
@@ -7201,7 +7687,18 @@ namespace fakeit {
             return AlwaysDo([e](const typename fakeit::test_arg<arglist>::type...) -> void { throw e; });
         }
 
-           template<typename F>
+        template<typename ... valuelist>
+        MethodStubbingProgress<void, arglist...> &
+        ReturnAndSet(valuelist &&... arg_vals) {
+            return Do(GetAssigner(std::forward<valuelist>(arg_vals)...));
+        }
+
+        template<typename ... valuelist>
+        void AlwaysReturnAndSet(valuelist &&... arg_vals) {
+            AlwaysDo(GetAssigner(std::forward<valuelist>(arg_vals)...));
+        }
+
+        template<typename F>
         MethodStubbingProgress<void, arglist...> &
         Do(const Quantifier<F> &q) {
             return DoImpl(new Repeat<void, arglist...>(q.value, q.quantity));
@@ -7224,9 +7721,193 @@ namespace fakeit {
 
     private:
         MethodStubbingProgress &operator=(const MethodStubbingProgress &other) = delete;
+
+        template<typename ... valuelist>
+#if __cplusplus >= 201402L
+        auto
+#else
+        std::function<void (typename fakeit::test_arg<arglist>::type...)>
+#endif
+        GetAssigner(valuelist &&... arg_vals) {
+            class Lambda {
+            public:
+                Lambda(valuelist &&... arg_vals)
+                    : vals_tuple{std::forward<valuelist>(arg_vals)...} {}
+
+                void operator()(typename fakeit::test_arg<arglist>::type... args) {
+                    helper::ParamWalker<sizeof...(valuelist)>::Assign(vals_tuple,
+                        std::forward<arglist>(args)...);
+                }
+
+            private:
+                ArgumentsTuple<valuelist...> vals_tuple;
+            };
+
+            return Lambda(std::forward<valuelist>(arg_vals)...);
+        }
+
+        template<typename ...T, int ...N>
+#if __cplusplus >= 201402L
+        auto
+#else
+        std::function<void (typename fakeit::test_arg<arglist>::type...)>
+#endif
+        GetAssigner(helper::ArgValue<T, N>... arg_vals) {
+            class Lambda {
+            public:
+                Lambda(helper::ArgValue<T, N>... arg_vals)
+                    : vals_tuple{std::forward<helper::ArgValue<T, N>>(arg_vals)...} {}
+
+                void operator()(typename fakeit::test_arg<arglist>::type... args) {
+                    helper::ArgValidator<sizeof...(arglist), sizeof...(T) - 1>::CheckPositions(vals_tuple);
+                    helper::Assign<1>(vals_tuple, std::forward<arglist>(args)...);
+                }
+
+            private:
+                ArgumentsTuple<helper::ArgValue<T, N>...> vals_tuple;
+            };
+
+            return Lambda(std::forward<helper::ArgValue<T, N>>(arg_vals)...);
+        }
+
     };
 
 
+    namespace helper
+    {
+        template <typename T, int N>
+        struct ArgValue
+        {
+            ArgValue(T &&v): value ( std::forward<T>(v) ) {}
+            constexpr static int pos = N;
+            T value;
+        };
+
+        template <int max_index, int tuple_index>
+        struct ArgValidator
+        {
+            template <typename ...T, int ...N>
+            static void CheckPositions(const std::tuple<ArgValue<T, N>...> arg_vals)
+            {
+#if __cplusplus >= 201402L
+                static_assert(std::get<tuple_index>(arg_vals).pos <= max_index,
+                    "Argument index out of range");
+                ArgValidator<max_index, tuple_index - 1>::CheckPositions(arg_vals);
+#else
+                (void)arg_vals;
+#endif
+            }
+        };
+
+        template <int max_index>
+        struct ArgValidator<max_index, -1>
+        {
+            template <typename T>
+            static void CheckPositions(T) {}
+        };
+
+        template <typename current_arg>
+        typename std::enable_if<std::is_pointer<current_arg>::value,
+            typename std::remove_pointer<current_arg>::type &>::type
+        GetArg(current_arg &&t)
+        {
+            return *t;
+        }
+
+        template <typename current_arg>
+        typename std::enable_if<!std::is_pointer<current_arg>::value, current_arg>::type
+        GetArg(current_arg &&t)
+        {
+            return std::forward<current_arg>(t);
+        }
+
+        template<int N>
+        struct ParamWalker {
+            template<typename current_arg, typename ... valuelist, typename ... arglist>
+            static void
+            Assign(ArgumentsTuple<valuelist...> arg_vals, current_arg &&p, arglist&&... args) {
+                ParamWalker<N - 1>::template Assign(arg_vals, std::forward<arglist>(args)...);
+                GetArg(std::forward<current_arg>(p)) = std::get<sizeof...(valuelist) - N>(arg_vals);
+            }
+        };
+
+        template<>
+        struct ParamWalker<0> {
+            template<typename ... valuelist, typename ... arglist>
+            static void Assign(ArgumentsTuple<valuelist...>, arglist... ) {}
+        };
+
+        template<int arg_index, int check_index>
+        struct ArgLocator {
+            template<typename current_arg, typename ...T, int ...N>
+            static void AssignArg(current_arg &&p, std::tuple<ArgValue<T, N>...> arg_vals) {
+#if __cplusplus >= 201703L
+                if constexpr (std::get<check_index>(arg_vals).pos == arg_index)
+                    GetArg(std::forward<current_arg>(p)) = std::get<check_index>(arg_vals).value;
+#else
+                if (std::get<check_index>(arg_vals).pos == arg_index)
+                    Set(std::forward<current_arg>(p), std::get<check_index>(arg_vals).value);
+#endif
+                else if (check_index > 0)
+                    ArgLocator<arg_index, check_index - 1>::AssignArg(std::forward<current_arg>(p), arg_vals);
+            }
+
+#if __cplusplus < 201703L
+        private:
+            template<typename T, typename U>
+            static
+            typename std::enable_if<std::is_convertible<U, decltype(GetArg(std::declval<T>()))>::value, void>::type
+            Set(T &&p, U &&v)
+            {
+                GetArg(std::forward<T>(p)) = v;
+            }
+
+            template<typename T, typename U>
+            static
+            typename std::enable_if<!std::is_convertible<U, decltype(GetArg(std::declval<T>()))>::value, void>::type
+            Set(T &&, U &&)
+            {
+                throw std::logic_error("ReturnAndSet(): Invalid value type");
+            }
+#endif
+
+        };
+
+        template<int arg_index>
+        struct ArgLocator<arg_index, -1> {
+            template<typename current_arg, typename T>
+            static void AssignArg(current_arg, T) {
+            }
+        };
+
+        template<int arg_index, typename current_arg, typename ...T, int ...N, typename ... arglist>
+        static void
+        Assign(std::tuple<ArgValue<T, N>...> arg_vals, current_arg &&p, arglist &&... args) {
+            ArgLocator<arg_index, sizeof...(N) - 1>::AssignArg(std::forward<current_arg>(p), arg_vals);
+            Assign<arg_index + 1>(arg_vals, std::forward<arglist>(args)...);
+        }
+
+        template<int arg_index,  typename ... valuelist>
+        static void Assign(std::tuple<valuelist...>) {}
+
+    }
+
+
+    namespace placeholders
+    {
+        using namespace std::placeholders;
+
+        template <typename PlaceHolder, typename ArgType,
+            typename std::enable_if<static_cast<bool>(std::is_placeholder<PlaceHolder>::value), bool>::type = true>
+        helper::ArgValue<ArgType, std::is_placeholder<PlaceHolder>::value>
+        operator<=(PlaceHolder, ArgType &&arg)
+        {
+            return { std::forward<ArgType>(arg) };
+        }
+
+    }
+
+    using placeholders::operator <=;
 }
 #include <vector>
 #include <functional>
@@ -7354,7 +8035,8 @@ namespace fakeit {
     struct SpyingContext : Xaction {
         virtual void appendAction(Action<R, arglist...> *action) = 0;
 
-        virtual std::function<R(arglist&...)> getOriginalMethod() = 0;
+        virtual std::function<R(arglist&...)> getOriginalMethodCopyArgs() = 0;
+        virtual std::function<R(arglist&...)> getOriginalMethodForwardArgs() = 0;
     };
 }
 namespace fakeit {
@@ -7389,8 +8071,11 @@ namespace fakeit {
         template<std::size_t N>
         using NakedArgType = typename naked_type<ArgType<index>>::type;
 
-        template<std::size_t N>
-        using ArgMatcherCreatorType = decltype(std::declval<TypedMatcherCreator<NakedArgType<N>>>());
+        template <typename MatcherCreatorT, typename = void>
+        struct IsMatcherCreatorTypeCompatible : std::false_type {};
+
+        template <typename MatcherCreatorT>
+        struct IsMatcherCreatorTypeCompatible<MatcherCreatorT, typename std::enable_if<MatcherCreatorT::template IsTypeCompatible<NakedArgType<index>>::value, void>::type> : std::true_type {};
 
         MatchersCollector(std::vector<Destructible *> &matchers)
                 : _matchers(matchers) {
@@ -7401,56 +8086,36 @@ namespace fakeit {
 
         template<typename Head>
         typename std::enable_if<
-                std::is_constructible<NakedArgType<index>, Head>::value, void>
-        ::type CollectMatchers(const Head &value) {
+                !std::is_same<AnyMatcher, typename naked_type<Head>::type>::value &&
+                !IsMatcherCreatorTypeCompatible<typename naked_type<Head>::type>::value &&
+                std::is_constructible<NakedArgType<index>, Head&&>::value, void>
+        ::type CollectMatchers(Head &&value) {
 
-            TypedMatcher<NakedArgType<index>> *d = Eq<NakedArgType<index>>(value).createMatcher();
+            TypedMatcher<NakedArgType<index>> *d = Eq(std::forward<Head>(value)).template createMatcher<NakedArgType<index>>();
             _matchers.push_back(d);
-        }
-
-        template<typename Head, typename ...Tail>
-        typename std::enable_if<
-                std::is_constructible<NakedArgType<index>, Head>::value
-                , void>
-        ::type CollectMatchers(const Head &head, const Tail &... tail) {
-            CollectMatchers(head);
-            MatchersCollector<index + 1, arglist...> c(_matchers);
-            c.CollectMatchers(tail...);
         }
 
         template<typename Head>
         typename std::enable_if<
-                std::is_base_of<TypedMatcherCreator<NakedArgType<index>>, Head>::value, void>
-        ::type CollectMatchers(const Head &creator) {
-            TypedMatcher<NakedArgType<index>> *d = creator.createMatcher();
+                IsMatcherCreatorTypeCompatible<typename naked_type<Head>::type>::value, void>
+        ::type CollectMatchers(Head &&creator) {
+            TypedMatcher<NakedArgType<index>> *d = creator.template createMatcher<NakedArgType<index>>();
             _matchers.push_back(d);
-        }
-
-        template<typename Head, typename ...Tail>
-
-        typename std::enable_if<
-                std::is_base_of<TypedMatcherCreator<NakedArgType<index>>, Head>::value, void>
-        ::type CollectMatchers(const Head &head, const Tail &... tail) {
-            CollectMatchers(head);
-            MatchersCollector<index + 1, arglist...> c(_matchers);
-            c.CollectMatchers(tail...);
         }
 
         template<typename Head>
         typename std::enable_if<
-                std::is_same<AnyMatcher, Head>::value, void>
-        ::type CollectMatchers(const Head &) {
-            TypedMatcher<NakedArgType<index>> *d = Any<NakedArgType<index>>().createMatcher();
+                std::is_same<AnyMatcher, typename naked_type<Head>::type>::value, void>
+        ::type CollectMatchers(Head &&) {
+            TypedMatcher<NakedArgType<index>> *d = Any().template createMatcher<NakedArgType<index>>();
             _matchers.push_back(d);
         }
 
         template<typename Head, typename ...Tail>
-        typename std::enable_if<
-                std::is_same<AnyMatcher, Head>::value, void>
-        ::type CollectMatchers(const Head &head, const Tail &... tail) {
-            CollectMatchers(head);
+        void CollectMatchers(Head &&head, Tail &&... tail) {
+            CollectMatchers(std::forward<Head>(head));
             MatchersCollector<index + 1, arglist...> c(_matchers);
-            c.CollectMatchers(tail...);
+            c.CollectMatchers(std::forward<Tail>(tail)...);
         }
 
     };
@@ -7471,7 +8136,8 @@ namespace fakeit {
         struct Context : Destructible {
 
 
-            virtual typename std::function<R(arglist&...)> getOriginalMethod() = 0;
+            virtual typename std::function<R(arglist&...)> getOriginalMethodCopyArgs() = 0;
+            virtual typename std::function<R(arglist&...)> getOriginalMethodForwardArgs() = 0;
 
             virtual std::string getMethodName() = 0;
 
@@ -7570,8 +8236,12 @@ namespace fakeit {
                 into.push_back(&getStubbingContext().getInvolvedMock());
             }
 
-            typename std::function<R(arglist &...)> getOriginalMethod() {
-                return getStubbingContext().getOriginalMethod();
+            typename std::function<R(arglist &...)> getOriginalMethodCopyArgs() {
+                return getStubbingContext().getOriginalMethodCopyArgs();
+            }
+
+            typename std::function<R(arglist &...)> getOriginalMethodForwardArgs() {
+                return getStubbingContext().getOriginalMethodForwardArgs();
             }
 
             void setInvocationMatcher(typename ActualInvocation<arglist...>::Matcher *matcher) {
@@ -7633,13 +8303,13 @@ namespace fakeit {
             _impl->setMethodDetails(mockName, methodName);
         }
 
-        void setMatchingCriteria(std::function<bool(arglist &...)> predicate) {
+        void setMatchingCriteria(const std::function<bool(arglist &...)>& predicate) {
             typename ActualInvocation<arglist...>::Matcher *matcher{
                     new UserDefinedInvocationMatcher<arglist...>(predicate)};
             _impl->setInvocationMatcher(matcher);
         }
 
-        void setMatchingCriteria(const std::vector<Destructible *> &matchers) {
+        void setMatchingCriteria(std::vector<Destructible *> &matchers) {
             typename ActualInvocation<arglist...>::Matcher *matcher{
                     new ArgumentsMatcherInvocationMatcher<arglist...>(matchers)};
             _impl->setInvocationMatcher(matcher);
@@ -7654,21 +8324,26 @@ namespace fakeit {
             _impl->setMethodBodyByAssignment(method);
         }
 
-        template<class ...matcherCreators, class = typename std::enable_if<
-                sizeof...(matcherCreators) == sizeof...(arglist)>::type>
-        void setMatchingCriteria(const matcherCreators &... matcherCreator) {
+        template<class ...matcherCreators>
+        typename std::enable_if<
+                sizeof...(matcherCreators) == sizeof...(arglist), void>
+        ::type setMatchingCriteria(matcherCreators &&... matcherCreator) {
             std::vector<Destructible *> matchers;
 
             MatchersCollector<0, arglist...> c(matchers);
-            c.CollectMatchers(matcherCreator...);
+            c.CollectMatchers(std::forward<matcherCreators>(matcherCreator)...);
 
             MethodMockingContext<R, arglist...>::setMatchingCriteria(matchers);
         }
 
     private:
 
-        typename std::function<R(arglist&...)> getOriginalMethod() override {
-            return _impl->getOriginalMethod();
+        typename std::function<R(arglist&...)> getOriginalMethodCopyArgs() override {
+            return _impl->getOriginalMethodCopyArgs();
+        }
+
+        typename std::function<R(arglist&...)> getOriginalMethodForwardArgs() override {
+            return _impl->getOriginalMethodForwardArgs();
         }
 
         std::shared_ptr<Implementation> _impl;
@@ -7696,18 +8371,13 @@ namespace fakeit {
             return *this;
         }
 
-        MockingContext<R, arglist...> &Using(const arglist &... args) {
-            MethodMockingContext<R, arglist...>::setMatchingCriteria(args...);
-            return *this;
-        }
-
         template<class ...arg_matcher>
-        MockingContext<R, arglist...> &Using(const arg_matcher &... arg_matchers) {
-            MethodMockingContext<R, arglist...>::setMatchingCriteria(arg_matchers...);
+        MockingContext<R, arglist...> &Using(arg_matcher &&... arg_matchers) {
+            MethodMockingContext<R, arglist...>::setMatchingCriteria(std::forward<arg_matcher>(arg_matchers)...);
             return *this;
         }
 
-        MockingContext<R, arglist...> &Matching(std::function<bool(arglist &...)> matcher) {
+        MockingContext<R, arglist...> &Matching(const std::function<bool(arglist &...)>& matcher) {
             MethodMockingContext<R, arglist...>::setMatchingCriteria(matcher);
             return *this;
         }
@@ -7717,7 +8387,7 @@ namespace fakeit {
             return *this;
         }
 
-        MockingContext<R, arglist...> &operator()(std::function<bool(arglist &...)> matcher) {
+        MockingContext<R, arglist...> &operator()(const std::function<bool(arglist &...)>& matcher) {
             MethodMockingContext<R, arglist...>::setMatchingCriteria(matcher);
             return *this;
         }
@@ -7761,18 +8431,13 @@ namespace fakeit {
             return *this;
         }
 
-        MockingContext<void, arglist...> &Using(const arglist &... args) {
-            MethodMockingContext<void, arglist...>::setMatchingCriteria(args...);
-            return *this;
-        }
-
         template<class ...arg_matcher>
-        MockingContext<void, arglist...> &Using(const arg_matcher &... arg_matchers) {
-            MethodMockingContext<void, arglist...>::setMatchingCriteria(arg_matchers...);
+        MockingContext<void, arglist...> &Using(arg_matcher &&... arg_matchers) {
+            MethodMockingContext<void, arglist...>::setMatchingCriteria(std::forward<arg_matcher>(arg_matchers)...);
             return *this;
         }
 
-        MockingContext<void, arglist...> &Matching(std::function<bool(arglist &...)> matcher) {
+        MockingContext<void, arglist...> &Matching(const std::function<bool(arglist &...)>& matcher) {
             MethodMockingContext<void, arglist...>::setMatchingCriteria(matcher);
             return *this;
         }
@@ -7782,7 +8447,7 @@ namespace fakeit {
             return *this;
         }
 
-        MockingContext<void, arglist...> &operator()(std::function<bool(arglist &...)> matcher) {
+        MockingContext<void, arglist...> &operator()(const std::function<bool(arglist &...)>& matcher) {
             MethodMockingContext<void, arglist...>::setMatchingCriteria(matcher);
             return *this;
         }
@@ -7830,21 +8495,12 @@ namespace fakeit {
         }
 
         MockImpl(FakeitContext &fakeit)
-                : MockImpl<C, baseclasses...>(fakeit, *(createFakeInstance()), false) {
-            FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
+                : MockImpl<C, baseclasses...>(fakeit, *(createFakeInstance()), false){
+            FakeObject<C, baseclasses...> *fake = asFakeObject(_instanceOwner.get());
             fake->getVirtualTable().setCookie(1, this);
         }
 
         virtual ~MockImpl() NO_THROWS {
-            _proxy.detach();
-            if (_isOwner) {
-                FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
-                delete fake;
-            }
-        }
-
-        void detach() {
-            _isOwner = false;
             _proxy.detach();
         }
 
@@ -7859,8 +8515,8 @@ namespace fakeit {
 
 	    void initDataMembersIfOwner()
 	    {
-		    if (_isOwner) {
-			    FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
+		    if (isOwner()) {
+			    FakeObject<C, baseclasses...> *fake = asFakeObject(_instanceOwner.get());
 			    fake->initializeDataMembersArea();
 		    }
 	    }
@@ -7904,11 +8560,34 @@ namespace fakeit {
             return DtorMockingContext(new DtorMockingContextImpl(*this));
         }
 
+
+
+
+
+
+
     private:
-        DynamicProxy<C, baseclasses...> _proxy;
-        C *_instance;
-        bool _isOwner;
+
+
+
+
+
+
+
+
+
+		std::shared_ptr<FakeObject<C, baseclasses...>> _instanceOwner;
+		DynamicProxy<C, baseclasses...> _proxy;
         FakeitContext &_fakeit;
+
+        MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
+                : _instanceOwner(isSpy ? nullptr : asFakeObject(&obj))
+				, _proxy{obj}
+				, _fakeit(fakeit) {}
+
+        static FakeObject<C, baseclasses...>* asFakeObject(void* instance){
+            return reinterpret_cast<FakeObject<C, baseclasses...> *>(instance);
+        }
 
         template<typename R, typename ... arglist>
         class MethodMockingContextBase : public MethodMockingContext<R, arglist...>::Context {
@@ -7962,8 +8641,28 @@ namespace fakeit {
                     : MethodMockingContextBase<R, arglist...>(mock), _vMethod(vMethod) {
             }
 
+            template<typename ... T, typename std::enable_if<all_true<std::is_copy_constructible<T>::value...>::value, int>::type = 0>
+            std::function<R(arglist&...)> getOriginalMethodCopyArgsInternal(int) {
+                void *mPtr = MethodMockingContextBase<R, arglist...>::_mock.getOriginalMethod(_vMethod);
+                C * instance = &(MethodMockingContextBase<R, arglist...>::_mock.get());
+                return [=](arglist&... args) -> R {
+                    auto m = union_cast<typename VTableMethodType<R,arglist...>::type>(mPtr);
+                    return m(instance, args...);
+                };
+            }
 
-            virtual std::function<R(arglist&...)> getOriginalMethod() override {
+
+            template<typename ... T>
+            [[noreturn]] std::function<R(arglist&...)> getOriginalMethodCopyArgsInternal(long) {
+                std::abort();
+            }
+
+
+            std::function<R(arglist&...)> getOriginalMethodCopyArgs() override {
+                return getOriginalMethodCopyArgsInternal<arglist...>(0);
+            }
+
+            std::function<R(arglist&...)> getOriginalMethodForwardArgs() override {
                 void *mPtr = MethodMockingContextBase<R, arglist...>::_mock.getOriginalMethod(_vMethod);
                 C * instance = &(MethodMockingContextBase<R, arglist...>::_mock.get());
                 return [=](arglist&... args) -> R {
@@ -8007,20 +8706,28 @@ namespace fakeit {
                     : MethodMockingContextBase<void>(mock) {
             }
 
-            virtual std::function<void()> getOriginalMethod() override {
-                C &instance = MethodMockingContextBase<void>::_mock.get();
-                return [=, &instance]() -> void {
+            std::function<void()> getOriginalMethodCopyArgs() override {
+                return [=]() -> void {
+                };
+            }
+
+            std::function<void()> getOriginalMethodForwardArgs() override {
+                return [=]() -> void {
                 };
             }
 
         };
 
         static MockImpl<C, baseclasses...> *getMockImpl(void *instance) {
-            FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(instance);
+            FakeObject<C, baseclasses...> *fake = asFakeObject(instance);
             MockImpl<C, baseclasses...> *mock = reinterpret_cast<MockImpl<C, baseclasses...> *>(fake->getVirtualTable().getCookie(
                     1));
             return mock;
         }
+
+        bool isOwner(){ return _instanceOwner != nullptr;}
+
+		void unmockedDtor() {}
 
         void unmocked() {
             ActualInvocation<> invocation(Invocation::nextInvocationOrdinal(), UnknownMethod::instance());
@@ -8036,8 +8743,11 @@ namespace fakeit {
         static C *createFakeInstance() {
             FakeObject<C, baseclasses...> *fake = new FakeObject<C, baseclasses...>();
             void *unmockedMethodStubPtr = union_cast<void *>(&MockImpl<C, baseclasses...>::unmocked);
-            fake->getVirtualTable().initAll(unmockedMethodStubPtr);
-            return reinterpret_cast<C *>(fake);
+			void *unmockedDtorStubPtr = union_cast<void *>(&MockImpl<C, baseclasses...>::unmockedDtor);
+			fake->getVirtualTable().initAll(unmockedMethodStubPtr);
+			if (VTUtils::hasVirtualDestructor<C>())
+				fake->setDtor(unmockedDtorStubPtr);
+			return reinterpret_cast<C *>(fake);
         }
 
         template<typename R, typename ... arglist>
@@ -8075,10 +8785,6 @@ namespace fakeit {
             return *dtorMock;
         }
 
-        MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
-                : _proxy{obj}, _instance(&obj), _isOwner(!isSpy), _fakeit(fakeit) {
-        }
-
         template<typename R, typename ... arglist>
         static RecordedMethodBody<R, arglist...> *createRecordedMethodBody(MockObject<C> &mock,
                                                                            R(C::*vMethod)(arglist...)) {
@@ -8088,7 +8794,6 @@ namespace fakeit {
         static RecordedMethodBody<void> *createRecordedDtorBody(MockObject<C> &mock) {
             return new RecordedMethodBody<void>(mock.getFakeIt(), "dtor");
         }
-
     };
 }
 namespace fakeit {
@@ -8142,7 +8847,6 @@ namespace fakeit {
 namespace fakeit {
     namespace internal {
     }
-    using namespace fakeit;
     using namespace fakeit::internal;
 
     template<typename C, typename ... baseclasses>
@@ -8163,7 +8867,11 @@ namespace fakeit {
             return impl.get();
         }
 
-        C &operator()() {
+
+
+
+
+		C &operator()() {
             return get();
         }
 
@@ -8333,7 +9041,7 @@ namespace fakeit {
 
             virtual ~StubbingChange() THROWS {
 
-                if (std::uncaught_exception()) {
+                if (UncaughtException()) {
                     return;
                 }
 
@@ -8593,7 +9301,7 @@ namespace fakeit {
         friend class SequenceVerificationProgress;
 
         ~SequenceVerificationExpectation() THROWS {
-            if (std::uncaught_exception()) {
+            if (UncaughtException()) {
                 return;
             }
             VerifyExpectation(_fakeit);
@@ -8605,6 +9313,10 @@ namespace fakeit {
 
         void setExpectedCount(const int count) {
             _expectedCount = count;
+        }
+
+        void expectAnything() {
+            _expectAnything = true;
         }
 
         void setFileInfo(const char * file, int line, const char * callingMethod) {
@@ -8619,6 +9331,7 @@ namespace fakeit {
         InvocationsSourceProxy _involvedInvocationSources;
         std::vector<Sequence *> _expectedPattern;
         int _expectedCount;
+        bool _expectAnything;
 
         const char * _file;
         int _line;
@@ -8633,6 +9346,7 @@ namespace fakeit {
                 _involvedInvocationSources(mocks),
                 _expectedPattern(expectedPattern),
                 _expectedCount(-1),
+                _expectAnything(false),
                 _line(0),
                 _isVerified(false) {
         }
@@ -8646,12 +9360,14 @@ namespace fakeit {
             MatchAnalysis ma;
             ma.run(_involvedInvocationSources, _expectedPattern);
 
-            if (isAtLeastVerification() && atLeastLimitNotReached(ma.count)) {
-                return handleAtLeastVerificationEvent(verificationErrorHandler, ma.actualSequence, ma.count);
-            }
+            if (isNotAnythingVerification()) {
+                if (isAtLeastVerification() && atLeastLimitNotReached(ma.count)) {
+                    return handleAtLeastVerificationEvent(verificationErrorHandler, ma.actualSequence, ma.count);
+                }
 
-            if (isExactVerification() && exactLimitNotMatched(ma.count)) {
-                return handleExactVerificationEvent(verificationErrorHandler, ma.actualSequence, ma.count);
+                if (isExactVerification() && exactLimitNotMatched(ma.count)) {
+                    return handleExactVerificationEvent(verificationErrorHandler, ma.actualSequence, ma.count);
+                }
             }
 
             markAsVerified(ma.matchedInvocations);
@@ -8675,6 +9391,10 @@ namespace fakeit {
             }
         }
 
+        bool isNotAnythingVerification() {
+            return !_expectAnything;
+        }
+
         bool isAtLeastVerification() {
 
             return _expectedCount < 0;
@@ -8684,12 +9404,12 @@ namespace fakeit {
             return !isAtLeastVerification();
         }
 
-        bool atLeastLimitNotReached(int count) {
-            return count < -_expectedCount;
+        bool atLeastLimitNotReached(int actualCount) {
+            return actualCount < -_expectedCount;
         }
 
-        bool exactLimitNotMatched(int count) {
-            return count != _expectedCount;
+        bool exactLimitNotMatched(int actualCount) {
+            return actualCount != _expectedCount;
         }
 
         void handleExactVerificationEvent(VerificationEventHandler &verificationErrorHandler,
@@ -8795,11 +9515,16 @@ namespace fakeit {
 
         ~SequenceVerificationProgress() THROWS { };
 
-        operator bool() {
+        operator bool() const {
             return Terminator(_expectationPtr);
         }
 
         bool operator!() const { return !Terminator(_expectationPtr); }
+
+        Terminator Any() {
+            _expectationPtr->expectAnything();
+            return Terminator(_expectationPtr);
+        }
 
         Terminator Never() {
             Exactly(0);
@@ -8955,7 +9680,7 @@ namespace fakeit {
             friend class VerifyNoOtherInvocationsVerificationProgress;
 
             ~VerifyNoOtherInvocationsExpectation() THROWS {
-                if (std::uncaught_exception()) {
+                if (UncaughtException()) {
                     return;
                 }
 
@@ -9050,8 +9775,8 @@ namespace fakeit {
             return *this;
         }
 
-        operator bool() {
-            return toBool();
+        operator bool() const {
+            return const_cast<VerifyNoOtherInvocationsVerificationProgress *>(this)->toBool();
         }
 
         bool operator!() const { return !const_cast<VerifyNoOtherInvocationsVerificationProgress *>(this)->toBool(); }
@@ -9085,15 +9810,51 @@ namespace fakeit {
     };
 
 }
+#include <type_traits>
+
+
 namespace fakeit {
 
     class SpyFunctor {
     private:
 
+        template<typename R, typename ... arglist, typename std::enable_if<all_true<std::is_copy_constructible<arglist>::value...>::value, int>::type = 0>
+        void spy(const SpyingContext<R, arglist...> &root, int) {
+            SpyingContext<R, arglist...> &rootWithoutConst = const_cast<SpyingContext<R, arglist...> &>(root);
+            auto methodFromOriginalVT = rootWithoutConst.getOriginalMethodCopyArgs();
+            rootWithoutConst.appendAction(new ReturnDelegateValue<R, arglist...>(methodFromOriginalVT));
+            rootWithoutConst.commit();
+        }
+
+        template<typename R, typename ... arglist>
+        void spy(const SpyingContext<R, arglist...> &, long) {
+            static_assert(!std::is_same<R, R>::value, "Spy() cannot accept move-only args, use SpyWithoutVerify() instead which is able to forward these args but then they won't be available for Verify().");
+        }
+
+        void operator()() {
+        }
+
+    public:
+
+        template<typename H, typename ... M>
+        void operator()(const H &head, const M &... tail) {
+            spy(head, 0);
+            this->operator()(tail...);
+        }
+
+    };
+
+}
+
+namespace fakeit {
+
+    class SpyWithoutVerifyFunctor {
+    private:
+
         template<typename R, typename ... arglist>
         void spy(const SpyingContext<R, arglist...> &root) {
             SpyingContext<R, arglist...> &rootWithoutConst = const_cast<SpyingContext<R, arglist...> &>(root);
-            auto methodFromOriginalVT = rootWithoutConst.getOriginalMethod();
+            auto methodFromOriginalVT = rootWithoutConst.getOriginalMethodForwardArgs();
             rootWithoutConst.appendAction(new ReturnDelegateValue<R, arglist...>(methodFromOriginalVT));
             rootWithoutConst.commit();
         }
@@ -9112,7 +9873,6 @@ namespace fakeit {
     };
 
 }
-
 #include <vector>
 #include <set>
 
@@ -9182,6 +9942,7 @@ namespace fakeit {
     static VerifyNoOtherInvocationsFunctor VerifyNoOtherInvocations(Fakeit);
     static UnverifiedFunctor Unverified(Fakeit);
     static SpyFunctor Spy;
+    static SpyWithoutVerifyFunctor SpyWithoutVerify;
     static FakeFunctor Fake;
     static WhenFunctor When;
 
@@ -9195,6 +9956,7 @@ namespace fakeit {
             use(&Fake);
             use(&When);
             use(&Spy);
+            use(&SpyWithoutVerify);
             use(&Using);
             use(&Verify);
             use(&VerifyNoOtherInvocations);
@@ -9208,25 +9970,25 @@ namespace fakeit {
 #endif
 
 #define MOCK_TYPE(mock) \
-    std::remove_reference<decltype(mock.get())>::type
+    std::remove_reference<decltype((mock).get())>::type
 
 #define OVERLOADED_METHOD_PTR(mock, method, prototype) \
-    fakeit::Prototype<prototype>::MemberType<MOCK_TYPE(mock)>::get(&MOCK_TYPE(mock)::method)
+    fakeit::Prototype<prototype>::MemberType<typename MOCK_TYPE(mock)>::get(&MOCK_TYPE(mock)::method)
 
 #define CONST_OVERLOADED_METHOD_PTR(mock, method, prototype) \
-    fakeit::Prototype<prototype>::MemberType<MOCK_TYPE(mock)>::getconst(&MOCK_TYPE(mock)::method)
+    fakeit::Prototype<prototype>::MemberType<typename MOCK_TYPE(mock)>::getconst(&MOCK_TYPE(mock)::method)
 
 #define Dtor(mock) \
-    mock.dtor().setMethodDetails(#mock,"destructor")
+    (mock).dtor().setMethodDetails(#mock,"destructor")
 
 #define Method(mock, method) \
-    mock.template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
+    (mock).template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
 
 #define OverloadedMethod(mock, method, prototype) \
-    mock.template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define ConstOverloadedMethod(mock, method, prototype) \
-    mock.template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define Verify(...) \
         Verify( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)

--- a/rlclientlib/CMakeLists.txt
+++ b/rlclientlib/CMakeLists.txt
@@ -202,7 +202,7 @@ target_include_directories( rlclientlib
                             ${CMAKE_CURRENT_SOURCE_DIR}/../include
                             PRIVATE
                             ${CMAKE_CURRENT_SOURCE_DIR}
-                            ${FLATBUFFERS_INCLUDE_DIRS}
+                            ${FLATBUFFERS_INCLUDE_DIR}
                             ${CMAKE_CURRENT_SOURCE_DIR}/../ext_libs/date
                             )
 target_link_libraries(rlclientlib PUBLIC Boost::system vw_common vw_core PRIVATE RapidJSON)

--- a/rlclientlib/generic_event.cc
+++ b/rlclientlib/generic_event.cc
@@ -10,7 +10,7 @@ namespace reinforcement_learning {
   , _client_time_gmt(ts)
   , _payload_type(type)
   , _app_id(app_id)
-  , _context_string(context.to_string())
+  , _context_string(context)
   {}
 
   generic_event::generic_event(const char* id, const timestamp& ts, payload_type_t type, flatbuffers::DetachedBuffer&& payload, event_content_type content_type, object_list_t &&objects, const char* app_id, float pass_prob)

--- a/test_tools/joiner/CMakeLists.txt
+++ b/test_tools/joiner/CMakeLists.txt
@@ -3,4 +3,5 @@ add_executable(joiner.out
   text_converter.cc
 )
 
+target_include_directories(joiner.out PRIVATE ${FLATBUFFERS_INCLUDE_DIR})
 target_link_libraries(joiner.out PRIVATE Boost::program_options rlclientlib)

--- a/unit_test/configuration_test.cc
+++ b/unit_test/configuration_test.cc
@@ -4,7 +4,7 @@
 #endif
 
 #include <boost/test/unit_test.hpp>
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 
 #include "configuration.h"
 #include "config_utility.h"

--- a/unit_test/dedup_test.cc
+++ b/unit_test/dedup_test.cc
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(dedup_add_get_object)
   auto str = dict.get_object(id);
 
   BOOST_CHECK_EQUAL(5, str.size());
-  BOOST_CHECK_EQUAL("{abc}", str.to_string());
+  BOOST_CHECK_EQUAL("{abc}", str);
 }
 
 BOOST_AUTO_TEST_CASE(dedup_bad_json)


### PR DESCRIPTION
- CMake modified with correct Flatbuffers includes
- Added USE_LATEST_STD, taken from VW
- Made changes to avoid errors when compiling with C++ version newer than C++11
- Upgraded FakeIt to version 2.3.0 to be compatible with C++20