### PR TITLE
docs: Change readme to recommend vcpkg for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Linux Build Status)](https://img.shields.io/azure-devops/build/vowpalwabbit/3934113c-9e2b-4dbc-8972-72ab9b9b4342/23/master?label=Linux%20build&logo=Azure%20Devops)](https://dev.azure.com/vowpalwabbit/Vowpal%20Wabbit/_build?definitionId=31)
 [![MacOS Build Status](https://img.shields.io/azure-devops/build/vowpalwabbit/3934113c-9e2b-4dbc-8972-72ab9b9b4342/22/master?label=MacOS%20build&logo=Azure%20Devops)](https://dev.azure.com/vowpalwabbit/Vowpal%20Wabbit/_build?definitionId=32)
-[![Windows Build status](https://ci.appveyor.com/api/projects/status/57p7o5v34onsqma2/branch/master?svg=true)](https://ci.appveyor.com/project/JohnLangford/reinforcement-learning/branch/master)
 [![Integration with latest VW](https://github.com/VowpalWabbit/reinforcement_learning/actions/workflows/daily_integration.yml/badge.svg?event=schedule)](https://github.com/VowpalWabbit/reinforcement_learning/actions/workflows/daily_integration.yml)
 
 # RL Client Library
@@ -13,50 +12,40 @@ git clone https://github.com/VowpalWabbit/reinforcement_learning.git
 git submodule update --init --recursive
 ```
 
-## Ubuntu
 ### Dependencies
-Install the dependencies for this project with the following commands. We recommend the use of [vcpkg](https://github.com/microsoft/vcpkg) for installing `cpprestsdk` and `flatbuffers`.
+Install the dependencies for this project with the following commands. We recommend the use of [vcpkg](https://github.com/microsoft/vcpkg).
+
+Linux/MacOS
 ```sh
-sudo apt-get install libboost-all-dev libssl-dev
-vcpkg install cpprestsdk flatbuffers
+vcpkg install cpprestsdk flatbuffers boost-test boost-system boost-uuid boost-program-options boost-thread boost-math openssl zstd zlib fmt spdlog rapidjson
+```
+
+Windows
+```
+vcpkg install --triplet x64-windows cpprestsdk flatbuffers boost-test boost-system boost-uuid boost-program-options boost-thread boost-math openssl zstd zlib fmt spdlog rapidjson
 ```
 
 ### Configure + Build
 When configuring a CMake project using vcpkg dependencies, we must provide the full path to the `vcpkg.cmake` toolchain file.
 ```sh
-# Configure
-cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=</path/to/vcpkg>/scripts/buildsystems/vcpkg.cmake
+cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=</path/to/vcpkg>/scripts/buildsystems/vcpkg.cmake -DRAPIDJSON_SYS_DEP=On -DFMT_SYS_DEP=On -DSPDLOG_SYS_DEP=On -DVW_BOOST_MATH_SYS_DEP=On
+```
 
+Using `-G Ninja` is recommended as it provides automatic build parallelization.
+
+> Note: If your dependencies are static (e.g. MacOS vcpkg by default), then you will need to pass `-DRL_INTERNAL_BOOST_TEST_IS_SHARED_DEP=Off` to `cmake` when configuring.
+
+### Build
+
+```sh
 # Build
-cmake --build build -j `nproc`
-
-# Test
-cmake --build build --target rltest -j `nproc`
-cmake --build build --target test
+cmake --build build
 ```
 
-## MacOS
-### Dependencies
-MacOS dependencies can be managed through homebrew.
+### Test
 ```sh
-brew install cpprestsdk flatbuffers openssl
+ctest --test-dir build
 ```
-
-### Configure +  Build
-In order to build using homebrew dependencies, you must invoke cmake this way:
-```sh
-cmake -S . -B build -DOPENSSL_ROOT_DIR=`brew --prefix openssl` -DOPENSSL_LIBRARIES=`brew --prefix openssl`/lib
-cmake --build build --target all -j 4
-```
-
-## Windows
-### Dependencies
-Dependencies on Windows should be managed using [vcpkg](https://github.com/microsoft/vcpkg).
-```cmd
-vcpkg install --triplet x64-windows zlib boost-system boost-program-options boost-test boost-align boost-foreach boost-math boost-uuid cpprestsdk flatbuffers openssl
-```
-
-If needed, add the flatbuffers executables to your PATH: `<vcpkg_root>\installed\x64-windows\tools\flatbuffers`
 
 ### Configure + Build in Visual Studio
 Open the project directory in Visual Studio. Building the library can be easily done in the GUI.
@@ -68,61 +57,12 @@ Open the project directory in Visual Studio. Building the library can be easily 
 This procedure has been verified to work well in Visual Studio 2022.
 
 ### Configure with command line + Build in Visual Studio
-Alternatively, CMake configuration can be done in the command line.
-```cmd
-cmake -S . -B build  -DCMAKE_TOOLCHAIN_FILE=<vcpkg_root>\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -A x64 -G "Visual Studio 16 2019"
-rem Generates a solution you can open and use in Visual Studio
-.\build\reinforcement_learning.sln
+
+Follow instructions in [configure](#configure) but also include:
+```
+-DVCPKG_TARGET_TRIPLET=x64-windows -A x64 -G "Visual Studio 16 2019"
 ```
 
-Set VcpkgIntegration environment variable to `vcpkg.targets` file on your machine. Example:
-```
-VcpkgIntegration=c:\s\vcpkg\scripts\buildsystems\msbuild\vcpkg.targets
-```
+Or, change to whatever generator you wish.
 
-Open `reinforcement_learning.sln` in Visual Studio. Build Release or Debug x64 configuration.
-
-## Troubleshooting
-### OpenSSL on MacOS
-If you get an error similar to the following on MacOS when running `cmake ..`, then you may be able to fix it by supplying the OpenSSL path to CMake.
-```
-Make Error at /usr/local/Cellar/cmake/3.14.4/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:137 (message):
-  Could NOT find OpenSSL, try to set the path to OpenSSL root folder in the
-  system variable OPENSSL_ROOT_DIR (missing: OPENSSL_INCLUDE_DIR)
-Call Stack (most recent call first):
-  /usr/local/Cellar/cmake/3.14.4/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:378 (_FPHSA_FAILURE_MESSAGE)
-  /usr/local/Cellar/cmake/3.14.4/share/cmake/Modules/FindOpenSSL.cmake:413 (find_package_handle_standard_args)
-  /usr/local/Cellar/cmake/3.14.4/share/cmake/Modules/CMakeFindDependencyMacro.cmake:48 (find_package)
-  /usr/local/lib/cpprestsdk/cpprestsdk-config.cmake:11 (find_dependency)
-  CMakeLists.txt:9 (find_package)
-```
-
-This can be fixed by invoking CMake similar to the following:
-```bash
-cmake -DOPENSSL_ROOT_DIR=`brew --prefix openssl` -DOPENSSL_LIBRARIES=`brew --prefix openssl`/lib ..
-```
-
-### System cpprestsdk on Linux
-Installing cpprestsdk on Ubuntu18.04 using apt-get may result in cmake failing with:
-```
-CMake Error at CMakeLists.txt:9 (find_package):
-  By not providing "Findcpprestsdk.cmake" in CMAKE_MODULE_PATH this project
-  has asked CMake to find a package configuration file provided by
-  "cpprestsdk", but CMake did not find one.
-
-  Could not find a package configuration file provided by "cpprestsdk" with
-  any of the following names:
-
-    cpprestsdkConfig.cmake
-    cpprestsdk-config.cmake
-
-  Add the installation prefix of "cpprestsdk" to CMAKE_PREFIX_PATH or set
-  "cpprestsdk_DIR" to a directory containing one of the above files.  If
-  "cpprestsdk" provides a separate development package or SDK, be sure it has
-  been installed.
-```
-
-The workaround is to specify where to search
-```
-cmake .. -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/cmake
-```
+Then, open the generated solution in the build directory.

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -60,6 +60,14 @@ if(vw_USE_AZURE_FACTORIES)
   target_compile_definitions(rltest PRIVATE USE_AZURE_FACTORIES)
 endif()
 
+
+# By default assume boost is shared (old behavior)
+# Allow a caller to override this and say it is static
+option(RL_INTERNAL_BOOST_TEST_IS_SHARED_DEP "" ON)
+if(RL_INTERNAL_BOOST_TEST_IS_SHARED_DEP)
+  target_compile_definitions(rltest PRIVATE BOOST_TEST_DYN_LINK)
+endif()
+
 target_link_libraries(rltest
   PRIVATE
     rlclientlib

--- a/unit_test/async_batcher_test.cc
+++ b/unit_test/async_batcher_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/data_buffer_test.cc
+++ b/unit_test/data_buffer_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/data_callback_test.cc
+++ b/unit_test/data_callback_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/dedup_test.cc
+++ b/unit_test/dedup_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/err_callback_test.cc
+++ b/unit_test/err_callback_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/event_queue_test.cc
+++ b/unit_test/event_queue_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/explore_test.cc
+++ b/unit_test/explore_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/extensions/onnx/CMakeLists.txt
+++ b/unit_test/extensions/onnx/CMakeLists.txt
@@ -9,6 +9,13 @@ add_executable(rltest-onnx
   mock_helpers.cc
 )
 
+# By default assume boost is shared (old behavior)
+# Allow a caller to override this and say it is static
+option(RL_INTERNAL_BOOST_TEST_IS_SHARED_DEP "" ON)
+if(RL_INTERNAL_BOOST_TEST_IS_SHARED_DEP)
+  target_compile_definitions(rltest-onnx PRIVATE BOOST_TEST_DYN_LINK)
+endif()
+
 # Test Resources
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/mnist_data/)
@@ -46,6 +53,6 @@ add_custom_command(TARGET rltest-onnx POST_BUILD
   $<TARGET_FILE_DIR:rltest-onnx>
 )
 
-add_test(NAME rltest-onnx 
-  COMMAND $<TARGET_FILE:rltest-onnx> 
+add_test(NAME rltest-onnx
+  COMMAND $<TARGET_FILE:rltest-onnx>
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/unit_test/extensions/onnx/main.cc
+++ b/unit_test/extensions/onnx/main.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE Main
 #include <boost/test/unit_test.hpp>
 

--- a/unit_test/extensions/onnx/mnist_inference_test.cc
+++ b/unit_test/extensions/onnx/mnist_inference_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/extensions/onnx/tensor_notation_test.cc
+++ b/unit_test/extensions/onnx/tensor_notation_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/factory_test.cc
+++ b/unit_test/factory_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/fb_serializer_test.cc
+++ b/unit_test/fb_serializer_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/file_logger_test.cc
+++ b/unit_test/file_logger_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/header_auth_test.cc
+++ b/unit_test/header_auth_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/http_client_test.cc
+++ b/unit_test/http_client_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/http_transport_client_test.cc
+++ b/unit_test/http_transport_client_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/json_serializer_test.cc
+++ b/unit_test/json_serializer_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/learning_mode_test.cc
+++ b/unit_test/learning_mode_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/live_model_test.cc
+++ b/unit_test/live_model_test.cc
@@ -1,5 +1,4 @@
 #include "multi_slot_response.h"
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/main.cc
+++ b/unit_test/main.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE Main
 #include <boost/test/unit_test.hpp>
 

--- a/unit_test/mock_util.cc
+++ b/unit_test/mock_util.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 
 #include "mock_util.h"
 

--- a/unit_test/model_mgmt_test.cc
+++ b/unit_test/model_mgmt_test.cc
@@ -1,5 +1,4 @@
-﻿#define BOOST_TEST_DYN_LINK
-#ifdef STAND_ALONE
+﻿#ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif
 

--- a/unit_test/moving_queue_test.cc
+++ b/unit_test/moving_queue_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/multi_slot_response_detailed_test.cc
+++ b/unit_test/multi_slot_response_detailed_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/multistep_test.cc
+++ b/unit_test/multistep_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/object_pool_test.cc
+++ b/unit_test/object_pool_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/payload_serializer_test.cc
+++ b/unit_test/payload_serializer_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/preamble_test.cc
+++ b/unit_test/preamble_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/ranking_response_test.cc
+++ b/unit_test/ranking_response_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/safe_vw_test.cc
+++ b/unit_test/safe_vw_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/serializer.cc
+++ b/unit_test/serializer.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/sleeper_test.cc
+++ b/unit_test/sleeper_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/slot_ranking_test.cc
+++ b/unit_test/slot_ranking_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/status_builder_test.cc
+++ b/unit_test/status_builder_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/str_util_test.cc
+++ b/unit_test/str_util_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/time_tests.cc
+++ b/unit_test/time_tests.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/trace_logger_test.cc
+++ b/unit_test/trace_logger_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif

--- a/unit_test/watchdog_test.cc
+++ b/unit_test/watchdog_test.cc
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 #  define BOOST_TEST_MODULE Main
 #endif


### PR DESCRIPTION
Also, make it possible to link a static `boost-test`

TODO: change to use same boost detection as in https://github.com/VowpalWabbit/vowpal_wabbit/pull/4077