### PR TITLE
Add audit option

### DIFF
--- a/examples/basic_usage_cpp/basic_usage_cpp.cc
+++ b/examples/basic_usage_cpp/basic_usage_cpp.cc
@@ -17,17 +17,15 @@ int main()
 {
   // return basic_usage_cb();
   // return basic_usage_ca();
-  return basic_usage_ccb();
+  // return basic_usage_ccb();
   // return basic_usage_slates();
-  // return basic_usage_multistep();
+  return basic_usage_multistep();
 }
 
 int basic_usage_cb()
 {
   char const* const event_id = "event_id";
-  // char const* const context = R"({"shared":{"sf":1},"_multi":[ { "TAction":{"af":1} },{"TAction":{"af":2}}]})";
-  char const* const context =
-      R"({"FromUrl" : [ {"weather" : "sunny"} ], "_multi" : [ {"_tag" : "Mocha", "i" : {"constant" : 1, "id" : "Mocha"}, "j" : [ {"roast" : "light"} ]}, {"_tag" : "Latte", "i" : {"constant" : 1, "id" : "Latte"}, "j" : [ {"roast" : "dark"} ]}, {"_tag" : "Cappuccino", "i" : {"constant" : 1, "id" : "Cappuccino"}, "j" : [ {"roast" : "dark"} ]}]})";
+  char const* const context = R"({"shared":{"sf":1},"_multi":[ { "TAction":{"af":1} },{"TAction":{"af":2}}]})";
   float outcome = 1.0f;
 
   //! name, value based config object used to initialise the API
@@ -60,10 +58,6 @@ int basic_usage_cb()
   //! [(3) Choose an action]
   // Response class
   r::ranking_response response;
-
-  // for (int i = 0; i < 1000; i++) {
-  //  rl.choose_rank(event_id, context, response, &status);
-  //}
 
   if (rl.choose_rank(event_id, context, response, &status) != err::success)
   {
@@ -160,9 +154,8 @@ int basic_usage_ca()
 
 int basic_usage_ccb()
 {
-  char const* const event_id = "event_id";
   char const* const context =
-      R"({"shared":{"sf":1},"_multi":[ { "_tag": "Action1", "TAction":{"af":1} },{ "_tag": "Action2", "TAction":{"af":2}},{ "_tag": "Action3", "TAction":{"af":3}}],"_slots":[{"f":1}, {"f":2}]})";
+      R"({"shared":{"sf":1},"_multi":[ { "TAction":{"af":1} },{"TAction":{"af":2}},{"TAction":{"af":3}}],"_slots":[{"f":1}, {"f":2}]})";
 
   //! name, value based config object used to initialise the API
   u::configuration config;
@@ -193,11 +186,9 @@ int basic_usage_ccb()
 
   //! [(3) Choose an action]
   // Response class
-  // r::decision_response response;
+  r::decision_response response;
 
-  r::multi_slot_response response;
-
-  if (rl.request_multi_slot_decision(event_id, context, response, &status) != err::success)
+  if (rl.request_decision(context, response, &status) != err::success)
   {
     std::cout << status.get_error_msg() << std::endl;
     return -1;
@@ -208,7 +199,7 @@ int basic_usage_ccb()
   for (const auto& r : response)
   {
     const auto chosen_action = r.get_action_id();
-    if (rl.report_outcome(r.get_id(), 1.0f, &status) != err::success)
+    if (rl.report_outcome(r.get_slot_id(), 1.0f, &status) != err::success)
     {
       std::cout << status.get_error_msg() << std::endl;
       return -1;

--- a/examples/basic_usage_cpp/basic_usage_cpp.cc
+++ b/examples/basic_usage_cpp/basic_usage_cpp.cc
@@ -17,15 +17,17 @@ int main()
 {
   // return basic_usage_cb();
   // return basic_usage_ca();
-  // return basic_usage_ccb();
+  return basic_usage_ccb();
   // return basic_usage_slates();
-  return basic_usage_multistep();
+  // return basic_usage_multistep();
 }
 
 int basic_usage_cb()
 {
   char const* const event_id = "event_id";
-  char const* const context = R"({"shared":{"sf":1},"_multi":[ { "TAction":{"af":1} },{"TAction":{"af":2}}]})";
+  // char const* const context = R"({"shared":{"sf":1},"_multi":[ { "TAction":{"af":1} },{"TAction":{"af":2}}]})";
+  char const* const context =
+      R"({"FromUrl" : [ {"weather" : "sunny"} ], "_multi" : [ {"_tag" : "Mocha", "i" : {"constant" : 1, "id" : "Mocha"}, "j" : [ {"roast" : "light"} ]}, {"_tag" : "Latte", "i" : {"constant" : 1, "id" : "Latte"}, "j" : [ {"roast" : "dark"} ]}, {"_tag" : "Cappuccino", "i" : {"constant" : 1, "id" : "Cappuccino"}, "j" : [ {"roast" : "dark"} ]}]})";
   float outcome = 1.0f;
 
   //! name, value based config object used to initialise the API
@@ -58,6 +60,10 @@ int basic_usage_cb()
   //! [(3) Choose an action]
   // Response class
   r::ranking_response response;
+
+  // for (int i = 0; i < 1000; i++) {
+  //  rl.choose_rank(event_id, context, response, &status);
+  //}
 
   if (rl.choose_rank(event_id, context, response, &status) != err::success)
   {
@@ -154,8 +160,9 @@ int basic_usage_ca()
 
 int basic_usage_ccb()
 {
+  char const* const event_id = "event_id";
   char const* const context =
-      R"({"shared":{"sf":1},"_multi":[ { "TAction":{"af":1} },{"TAction":{"af":2}},{"TAction":{"af":3}}],"_slots":[{"f":1}, {"f":2}]})";
+      R"({"shared":{"sf":1},"_multi":[ { "_tag": "Action1", "TAction":{"af":1} },{ "_tag": "Action2", "TAction":{"af":2}},{ "_tag": "Action3", "TAction":{"af":3}}],"_slots":[{"f":1}, {"f":2}]})";
 
   //! name, value based config object used to initialise the API
   u::configuration config;
@@ -186,9 +193,11 @@ int basic_usage_ccb()
 
   //! [(3) Choose an action]
   // Response class
-  r::decision_response response;
+  // r::decision_response response;
 
-  if (rl.request_decision(context, response, &status) != err::success)
+  r::multi_slot_response response;
+
+  if (rl.request_multi_slot_decision(event_id, context, response, &status) != err::success)
   {
     std::cout << status.get_error_msg() << std::endl;
     return -1;
@@ -199,7 +208,7 @@ int basic_usage_ccb()
   for (const auto& r : response)
   {
     const auto chosen_action = r.get_action_id();
-    if (rl.report_outcome(r.get_slot_id(), 1.0f, &status) != err::success)
+    if (rl.report_outcome(r.get_id(), 1.0f, &status) != err::success)
     {
       std::cout << status.get_error_msg() << std::endl;
       return -1;

--- a/include/constants.h
+++ b/include/constants.h
@@ -3,9 +3,9 @@
 namespace reinforcement_learning
 {
 #ifdef _WIN32
-  const char* const delimiter = "\\";
+const char* const delimiter = "\\";
 #else
-  const char* const delimiter = "/";
+const char* const delimiter = "/";
 #endif
 
 namespace name

--- a/include/constants.h
+++ b/include/constants.h
@@ -3,9 +3,9 @@
 namespace reinforcement_learning
 {
 #ifdef _WIN32
-const char* const delimiter = "\\";
+const char* const PATH_DELIMITER = "\\";
 #else
-const char* const delimiter = "/";
+const char* const PATH_DELIMITER = "/";
 #endif
 
 namespace name

--- a/include/constants.h
+++ b/include/constants.h
@@ -133,7 +133,7 @@ const char* const QUEUE_MODE_BLOCK = "BLOCK";
 const bool DEFAULT_MODEL_BACKGROUND_REFRESH = true;
 const int DEFAULT_VW_POOL_INIT_SIZE = 4;
 const int DEFAULT_PROTOCOL_VERSION = 1;
-const char* DEFAULT_AUDIT_OUTPUT_PATH = "audit";
+const char* const DEFAULT_AUDIT_OUTPUT_PATH = "audit";
 
 const char* get_default_episode_sender();
 const char* get_default_observation_sender();

--- a/include/constants.h
+++ b/include/constants.h
@@ -2,6 +2,12 @@
 
 namespace reinforcement_learning
 {
+#ifdef _WIN32
+  const char* const delimiter = "\\";
+#else
+  const char* const delimiter = "/";
+#endif
+
 namespace name
 {
 const char* const APP_ID = "appid";
@@ -18,6 +24,8 @@ const char* const LEARNING_MODE = "rank.learning.mode";
 const char* const PROTOCOL_VERSION = "protocol.version";
 const char* const HTTP_API_KEY = "http.api.key";
 const char* const HTTP_API_HEADER_KEY_NAME = "http.api.header.key.name";
+const char* const AUDIT_ENABLED = "audit.enabled";
+const char* const AUDIT_OUTPUT_PATH = "audit.output.path";
 
 // Episode
 const char* const EPISODE_EH_HOST = "episode.eventhub.host";
@@ -125,6 +133,7 @@ const char* const QUEUE_MODE_BLOCK = "BLOCK";
 const bool DEFAULT_MODEL_BACKGROUND_REFRESH = true;
 const int DEFAULT_VW_POOL_INIT_SIZE = 4;
 const int DEFAULT_PROTOCOL_VERSION = 1;
+const char* DEFAULT_AUDIT_OUTPUT_PATH = "audit";
 
 const char* get_default_episode_sender();
 const char* get_default_observation_sender();

--- a/include/model_mgmt.h
+++ b/include/model_mgmt.h
@@ -84,9 +84,9 @@ public:
   virtual int request_multi_slot_decision(const char* event_id, const std::vector<std::string>& slot_ids,
       string_view features, std::vector<std::vector<uint32_t>>& actions_ids,
       std::vector<std::vector<float>>& action_pdfs, std::string& model_version, api_status* status = nullptr) = 0;
-  virtual int choose_rank_multistep(const char* event_id, uint64_t rnd_seed, string_view features, const episode_history& history,
-      std::vector<int>& action_ids, std::vector<float>& action_pdf, std::string& model_version,
-      api_status* status = nullptr) = 0;
+  virtual int choose_rank_multistep(const char* event_id, uint64_t rnd_seed, string_view features,
+      const episode_history& history, std::vector<int>& action_ids, std::vector<float>& action_pdf,
+      std::string& model_version, api_status* status = nullptr) = 0;
   virtual model_type_t model_type() const = 0;
   virtual ~i_model() = default;
 };

--- a/include/model_mgmt.h
+++ b/include/model_mgmt.h
@@ -74,7 +74,7 @@ class i_model
 {
 public:
   virtual int update(const model_data& data, bool& model_ready, api_status* status = nullptr) = 0;
-  virtual int choose_rank(uint64_t rnd_seed, string_view features, std::vector<int>& action_ids,
+  virtual int choose_rank(const char* event_id, uint64_t rnd_seed, string_view features, std::vector<int>& action_ids,
       std::vector<float>& action_pdf, std::string& model_version, api_status* status = nullptr) = 0;
   virtual int choose_continuous_action(string_view features, float& action, float& pdf_value,
       std::string& model_version, api_status* status = nullptr) = 0;
@@ -84,7 +84,7 @@ public:
   virtual int request_multi_slot_decision(const char* event_id, const std::vector<std::string>& slot_ids,
       string_view features, std::vector<std::vector<uint32_t>>& actions_ids,
       std::vector<std::vector<float>>& action_pdfs, std::string& model_version, api_status* status = nullptr) = 0;
-  virtual int choose_rank_multistep(uint64_t rnd_seed, string_view features, const episode_history& history,
+  virtual int choose_rank_multistep(const char* event_id, uint64_t rnd_seed, string_view features, const episode_history& history,
       std::vector<int>& action_ids, std::vector<float>& action_pdf, std::string& model_version,
       api_status* status = nullptr) = 0;
   virtual model_type_t model_type() const = 0;

--- a/rlclientlib/extensions/onnx/src/onnx_model.cc
+++ b/rlclientlib/extensions/onnx/src/onnx_model.cc
@@ -140,7 +140,7 @@ int onnx_model::update(const model_management::model_data& data, bool& model_rea
   return error_code::success;
 }
 
-int onnx_model::choose_rank(uint64_t rnd_seed, string_view features, std::vector<int>& action_ids,
+int onnx_model::choose_rank(const char* event_id, uint64_t rnd_seed, string_view features, std::vector<int>& action_ids,
     std::vector<float>& action_pdf, std::string& model_version, api_status* status)
 {
   std::shared_ptr<Ort::Session> local_session = _master_session;

--- a/rlclientlib/extensions/onnx/src/onnx_model.h
+++ b/rlclientlib/extensions/onnx/src/onnx_model.h
@@ -20,8 +20,8 @@ class onnx_model : public model_management::i_model
 public:
   onnx_model(i_trace* trace_logger, const char* app_id, const char* output_name, bool use_unstructured_input);
   int update(const model_management::model_data& data, bool& model_ready, api_status* status = nullptr) override;
-  int choose_rank(uint64_t rnd_seed, string_view features, std::vector<int>& action_ids, std::vector<float>& action_pdf,
-      std::string& model_version, api_status* status = nullptr) override;
+  int choose_rank(const char* event_id, uint64_t rnd_seed, string_view features, std::vector<int>& action_ids,
+      std::vector<float>& action_pdf, std::string& model_version, api_status* status = nullptr) override;
 
   int choose_continuous_action(string_view features, float& action, float& pdf_value, std::string& model_version,
       api_status* status = nullptr) override
@@ -43,9 +43,9 @@ public:
     return error_code::not_supported;
   }
 
-  int choose_rank_multistep(uint64_t rnd_seed, string_view features, const episode_history& history,
-      std::vector<int>& action_ids, std::vector<float>& action_pdf, std::string& model_version,
-      api_status* status = nullptr) override
+  int choose_rank_multistep(const char* event_id, uint64_t rnd_seed, string_view features,
+      const episode_history& history, std::vector<int>& action_ids, std::vector<float>& action_pdf,
+      std::string& model_version, api_status* status = nullptr) override
   {
     return error_code::not_supported;
   }

--- a/rlclientlib/live_model_impl.cc
+++ b/rlclientlib/live_model_impl.cc
@@ -639,7 +639,7 @@ int live_model_impl::explore_exploit(
   std::vector<int> action_ids;
   std::vector<float> action_pdf;
   std::string model_version;
-  
+
   RETURN_IF_FAIL(_model->choose_rank(event_id, seed, context, action_ids, action_pdf, model_version, status));
 
   return sample_and_populate_response(

--- a/rlclientlib/live_model_impl.cc
+++ b/rlclientlib/live_model_impl.cc
@@ -68,6 +68,7 @@ int live_model_impl::init(api_status* status)
   _initial_epsilon = _configuration.get_float(name::INITIAL_EPSILON, 0.2f);
   const char* app_id = _configuration.get(name::APP_ID, "");
   _seed_shift = VW::uniform_hash(app_id, strlen(app_id), 0);
+
   return error_code::success;
 }
 
@@ -638,8 +639,8 @@ int live_model_impl::explore_exploit(
   std::vector<int> action_ids;
   std::vector<float> action_pdf;
   std::string model_version;
-
-  RETURN_IF_FAIL(_model->choose_rank(seed, context, action_ids, action_pdf, model_version, status));
+  
+  RETURN_IF_FAIL(_model->choose_rank(event_id, seed, context, action_ids, action_pdf, model_version, status));
 
   return sample_and_populate_response(
       seed, action_ids, action_pdf, std::move(model_version), response, _trace_logger.get(), status);
@@ -683,7 +684,7 @@ int live_model_impl::request_episodic_decision(const char* event_id, const char*
   const std::string context_patched = history.get_context(previous_id, context_json);
 
   RETURN_IF_FAIL(_model->choose_rank_multistep(
-      seed, context_patched.c_str(), history, action_ids, action_pdf, model_version, status));
+      event_id, seed, context_patched.c_str(), history, action_ids, action_pdf, model_version, status));
   RETURN_IF_FAIL(sample_and_populate_response(
       seed, action_ids, action_pdf, std::move(model_version), resp, _trace_logger.get(), status));
 

--- a/rlclientlib/utility/config_utility.cc
+++ b/rlclientlib/utility/config_utility.cc
@@ -125,7 +125,9 @@ int translate_property(
       {"LearningMode", name::LEARNING_MODE}, {"learningMode", name::LEARNING_MODE},
       {"InitialCommandLine", name::MODEL_VW_INITIAL_COMMAND_LINE},
       {"initialCommandLine", name::MODEL_VW_INITIAL_COMMAND_LINE}, {"ProtocolVersion", name::PROTOCOL_VERSION},
-      {"protocolVersion", name::PROTOCOL_VERSION}};
+      {"protocolVersion", name::PROTOCOL_VERSION},
+      {"AuditEnabled", name::AUDIT_ENABLED},
+      {"AuditOutputPath", name::AUDIT_OUTPUT_PATH}};
 
   static const std::unordered_map<std::string, std::string> parsed_translation_mapping = {
       {"EventHubEpisodeConnectionString", "episode"}, {"eventHubEpisodeConnectionString", "episode"},

--- a/rlclientlib/utility/config_utility.cc
+++ b/rlclientlib/utility/config_utility.cc
@@ -125,8 +125,7 @@ int translate_property(
       {"LearningMode", name::LEARNING_MODE}, {"learningMode", name::LEARNING_MODE},
       {"InitialCommandLine", name::MODEL_VW_INITIAL_COMMAND_LINE},
       {"initialCommandLine", name::MODEL_VW_INITIAL_COMMAND_LINE}, {"ProtocolVersion", name::PROTOCOL_VERSION},
-      {"protocolVersion", name::PROTOCOL_VERSION},
-      {"AuditEnabled", name::AUDIT_ENABLED},
+      {"protocolVersion", name::PROTOCOL_VERSION}, {"AuditEnabled", name::AUDIT_ENABLED},
       {"AuditOutputPath", name::AUDIT_OUTPUT_PATH}};
 
   static const std::unordered_map<std::string, std::string> parsed_translation_mapping = {

--- a/rlclientlib/vw_model/pdf_model.cc
+++ b/rlclientlib/vw_model/pdf_model.cc
@@ -23,7 +23,7 @@ int pdf_model::update(const model_data& data, bool& model_ready, api_status* sta
   return error_code::success;
 }
 
-int pdf_model::choose_rank(uint64_t rnd_seed, string_view features, std::vector<int>& action_ids,
+int pdf_model::choose_rank(const char* event_id, uint64_t rnd_seed, string_view features, std::vector<int>& action_ids,
     std::vector<float>& action_pdf, std::string& model_version, api_status* status)
 {
   try
@@ -68,7 +68,7 @@ int pdf_model::request_multi_slot_decision(const char* event_id, const std::vect
 
 model_type_t pdf_model::model_type() const { return model_type_t::CB; }
 
-int pdf_model::choose_rank_multistep(uint64_t rnd_seed, string_view features, const episode_history& history,
+int pdf_model::choose_rank_multistep(const char* event_id, uint64_t rnd_seed, string_view features, const episode_history& history,
     std::vector<int>& action_ids, std::vector<float>& action_pdf, std::string& model_version, api_status* status)
 {
   return error_code::not_supported;

--- a/rlclientlib/vw_model/pdf_model.cc
+++ b/rlclientlib/vw_model/pdf_model.cc
@@ -68,8 +68,9 @@ int pdf_model::request_multi_slot_decision(const char* event_id, const std::vect
 
 model_type_t pdf_model::model_type() const { return model_type_t::CB; }
 
-int pdf_model::choose_rank_multistep(const char* event_id, uint64_t rnd_seed, string_view features, const episode_history& history,
-    std::vector<int>& action_ids, std::vector<float>& action_pdf, std::string& model_version, api_status* status)
+int pdf_model::choose_rank_multistep(const char* event_id, uint64_t rnd_seed, string_view features,
+    const episode_history& history, std::vector<int>& action_ids, std::vector<float>& action_pdf,
+    std::string& model_version, api_status* status)
 {
   return error_code::not_supported;
 }

--- a/rlclientlib/vw_model/pdf_model.h
+++ b/rlclientlib/vw_model/pdf_model.h
@@ -20,7 +20,7 @@ class pdf_model : public i_model
 public:
   pdf_model(i_trace* trace_logger, const utility::configuration& config);
   int update(const model_data& data, bool& model_ready, api_status* status = nullptr) override;
-  int choose_rank(uint64_t rnd_seed, string_view features, std::vector<int>& action_ids, std::vector<float>& action_pdf,
+  int choose_rank(const char* event_id, uint64_t rnd_seed, string_view features, std::vector<int>& action_ids, std::vector<float>& action_pdf,
       std::string& model_version, api_status* status = nullptr) override;
   int choose_continuous_action(string_view features, float& action, float& pdf_value, std::string& model_version,
       api_status* status = nullptr) override;
@@ -30,7 +30,7 @@ public:
   int request_multi_slot_decision(const char* event_id, const std::vector<std::string>& slot_ids, string_view features,
       std::vector<std::vector<uint32_t>>& actions_ids, std::vector<std::vector<float>>& action_pdfs,
       std::string& model_version, api_status* status = nullptr) override;
-  int choose_rank_multistep(uint64_t rnd_seed, string_view features, const episode_history& history,
+  int choose_rank_multistep(const char* event_id, uint64_t rnd_seed, string_view features, const episode_history& history,
       std::vector<int>& action_ids, std::vector<float>& action_pdf, std::string& model_version,
       api_status* status = nullptr) override;
   model_type_t model_type() const override;

--- a/rlclientlib/vw_model/pdf_model.h
+++ b/rlclientlib/vw_model/pdf_model.h
@@ -20,8 +20,8 @@ class pdf_model : public i_model
 public:
   pdf_model(i_trace* trace_logger, const utility::configuration& config);
   int update(const model_data& data, bool& model_ready, api_status* status = nullptr) override;
-  int choose_rank(const char* event_id, uint64_t rnd_seed, string_view features, std::vector<int>& action_ids, std::vector<float>& action_pdf,
-      std::string& model_version, api_status* status = nullptr) override;
+  int choose_rank(const char* event_id, uint64_t rnd_seed, string_view features, std::vector<int>& action_ids,
+      std::vector<float>& action_pdf, std::string& model_version, api_status* status = nullptr) override;
   int choose_continuous_action(string_view features, float& action, float& pdf_value, std::string& model_version,
       api_status* status = nullptr) override;
   int request_decision(const std::vector<const char*>& event_ids, string_view features,
@@ -30,9 +30,9 @@ public:
   int request_multi_slot_decision(const char* event_id, const std::vector<std::string>& slot_ids, string_view features,
       std::vector<std::vector<uint32_t>>& actions_ids, std::vector<std::vector<float>>& action_pdfs,
       std::string& model_version, api_status* status = nullptr) override;
-  int choose_rank_multistep(const char* event_id, uint64_t rnd_seed, string_view features, const episode_history& history,
-      std::vector<int>& action_ids, std::vector<float>& action_pdf, std::string& model_version,
-      api_status* status = nullptr) override;
+  int choose_rank_multistep(const char* event_id, uint64_t rnd_seed, string_view features,
+      const episode_history& history, std::vector<int>& action_ids, std::vector<float>& action_pdf,
+      std::string& model_version, api_status* status = nullptr) override;
   model_type_t model_type() const override;
 
 private:

--- a/rlclientlib/vw_model/safe_vw.cc
+++ b/rlclientlib/vw_model/safe_vw.cc
@@ -44,7 +44,7 @@ safe_vw::safe_vw(const char* model_data, size_t len, const std::string& vw_comma
 }
 
 safe_vw::safe_vw(const std::string& vw_commandline)
-{ 
+{
   _vw = VW::initialize(vw_commandline);
   init();
 }
@@ -81,10 +81,7 @@ VW::example* safe_vw::get_or_create_example()
   return ex;
 }
 
-VW::example& safe_vw::get_or_create_example_f(void* vw)
-{
-    return *(((safe_vw*)vw)->get_or_create_example());
-}
+VW::example& safe_vw::get_or_create_example_f(void* vw) { return *(((safe_vw*)vw)->get_or_create_example()); }
 
 void safe_vw::parse_context_with_pdf(string_view context, std::vector<int>& actions, std::vector<float>& scores)
 {
@@ -99,13 +96,13 @@ void safe_vw::parse_context_with_pdf(string_view context, std::vector<int>& acti
   if (_vw->audit)
   {
     _vw->audit_buffer->clear();
-	VW::read_line_decision_service_json<true>(
-		  *_vw, examples, &line_vec[0], line_vec.size(), false, get_or_create_example_f, this, &interaction);
+    VW::read_line_decision_service_json<true>(
+        *_vw, examples, &line_vec[0], line_vec.size(), false, get_or_create_example_f, this, &interaction);
   }
   else
   {
-	VW::read_line_decision_service_json<false>(
-		  *_vw, examples, &line_vec[0], line_vec.size(), false, get_or_create_example_f, this, &interaction);
+    VW::read_line_decision_service_json<false>(
+        *_vw, examples, &line_vec[0], line_vec.size(), false, get_or_create_example_f, this, &interaction);
   }
 
   // finalize example
@@ -370,21 +367,19 @@ bool safe_vw::is_CB_to_CCB_model_upgrade(const std::string& args) const
   return local_model_type == mm::model_type_t::CCB && inbound_model_type == mm::model_type_t::CB;
 }
 
-const char* safe_vw::get_audit_data() const 
-{ 
-  if (_vw->audit)
-  { 
-    return &(*(_vw->audit_buffer))[0];
-  }
+const char* safe_vw::get_audit_data() const
+{
+  if (_vw->audit) { return &(*(_vw->audit_buffer))[0]; }
   else
-  { 
+  {
     return nullptr;
   }
 }
 
 void safe_vw::init()
 {
-  if (_vw->audit) {
+  if (_vw->audit)
+  {
     _vw->audit_buffer = std::make_shared<std::vector<char>>();
     _vw->audit_writer = VW::io::create_vector_writer(_vw->audit_buffer);
   }

--- a/rlclientlib/vw_model/safe_vw.cc
+++ b/rlclientlib/vw_model/safe_vw.cc
@@ -367,12 +367,11 @@ bool safe_vw::is_CB_to_CCB_model_upgrade(const std::string& args) const
   return local_model_type == mm::model_type_t::CCB && inbound_model_type == mm::model_type_t::CB;
 }
 
-const char* safe_vw::get_audit_data() const
+string_view safe_vw::get_audit_data() const
 {
-  if (_vw->audit) { return &(*(_vw->audit_buffer))[0]; }
+  if (_vw->audit) { return string_view(_vw->audit_buffer->data(), _vw->audit_buffer->size()); }
   else
-  {
-    return nullptr;
+  { return string_view();
   }
 }
 

--- a/rlclientlib/vw_model/safe_vw.cc
+++ b/rlclientlib/vw_model/safe_vw.cc
@@ -22,6 +22,7 @@ static const std::string SEED_TAG = "seed=";
 safe_vw::safe_vw(std::shared_ptr<safe_vw> master) : _master(std::move(master))
 {
   _vw = VW::seed_vw_model(_master->_vw, "", nullptr, nullptr);
+  init();
 }
 
 safe_vw::safe_vw(const char* model_data, size_t len)
@@ -30,6 +31,7 @@ safe_vw::safe_vw(const char* model_data, size_t len)
   buf.add_file(VW::io::create_buffer_view(model_data, len));
 
   _vw = VW::initialize("--quiet --json", &buf, false, nullptr, nullptr);
+  init();
 }
 
 safe_vw::safe_vw(const char* model_data, size_t len, const std::string& vw_commandline)
@@ -38,9 +40,14 @@ safe_vw::safe_vw(const char* model_data, size_t len, const std::string& vw_comma
   buf.add_file(VW::io::create_buffer_view(model_data, len));
 
   _vw = VW::initialize(vw_commandline, &buf, false, nullptr, nullptr);
+  init();
 }
 
-safe_vw::safe_vw(const std::string& vw_commandline) { _vw = VW::initialize(vw_commandline); }
+safe_vw::safe_vw(const std::string& vw_commandline)
+{ 
+  _vw = VW::initialize(vw_commandline);
+  init();
+}
 
 safe_vw::~safe_vw()
 {
@@ -74,7 +81,10 @@ VW::example* safe_vw::get_or_create_example()
   return ex;
 }
 
-VW::example& safe_vw::get_or_create_example_f(void* vw) { return *(((safe_vw*)vw)->get_or_create_example()); }
+VW::example& safe_vw::get_or_create_example_f(void* vw)
+{
+    return *(((safe_vw*)vw)->get_or_create_example());
+}
 
 void safe_vw::parse_context_with_pdf(string_view context, std::vector<int>& actions, std::vector<float>& scores)
 {
@@ -86,8 +96,17 @@ void safe_vw::parse_context_with_pdf(string_view context, std::vector<int>& acti
   // copy due to destructive parsing by rapidjson
   std::string line_vec(context);
 
-  VW::read_line_decision_service_json<false>(
-      *_vw, examples, &line_vec[0], line_vec.size(), false, get_or_create_example_f, this, &interaction);
+  if (_vw->audit)
+  {
+    _vw->audit_buffer->clear();
+	VW::read_line_decision_service_json<true>(
+		  *_vw, examples, &line_vec[0], line_vec.size(), false, get_or_create_example_f, this, &interaction);
+  }
+  else
+  {
+	VW::read_line_decision_service_json<false>(
+		  *_vw, examples, &line_vec[0], line_vec.size(), false, get_or_create_example_f, this, &interaction);
+  }
 
   // finalize example
   VW::setup_examples(*_vw, examples);
@@ -112,7 +131,15 @@ void safe_vw::rank(string_view context, std::vector<int>& actions, std::vector<f
   // copy due to destructive parsing by rapidjson
   std::string line_vec(context);
 
-  VW::read_line_json_s<false>(*_vw, examples, &line_vec[0], line_vec.size(), get_or_create_example_f, this);
+  if (_vw->audit)
+  {
+    _vw->audit_buffer->clear();
+    VW::read_line_json_s<true>(*_vw, examples, &line_vec[0], line_vec.size(), get_or_create_example_f, this);
+  }
+  else
+  {
+    VW::read_line_json_s<false>(*_vw, examples, &line_vec[0], line_vec.size(), get_or_create_example_f, this);
+  }
 
   // finalize example
   VW::setup_examples(*_vw, examples);
@@ -148,7 +175,15 @@ void safe_vw::choose_continuous_action(string_view context, float& action, float
   // copy due to destructive parsing by rapidjson
   std::string line_vec(context);
 
-  VW::read_line_json_s<false>(*_vw, examples, &line_vec[0], line_vec.size(), get_or_create_example_f, this);
+  if (_vw->audit)
+  {
+    _vw->audit_buffer->clear();
+    VW::read_line_json_s<true>(*_vw, examples, &line_vec[0], line_vec.size(), get_or_create_example_f, this);
+  }
+  else
+  {
+    VW::read_line_json_s<false>(*_vw, examples, &line_vec[0], line_vec.size(), get_or_create_example_f, this);
+  }
 
   // finalize example
   VW::setup_examples(*_vw, examples);
@@ -174,7 +209,15 @@ void safe_vw::rank_decisions(const std::vector<const char*>& event_ids, string_v
   // copy due to destructive parsing by rapidjson
   std::string line_vec(context);
 
-  VW::read_line_json_s<false>(*_vw, examples, &line_vec[0], line_vec.size(), get_or_create_example_f, this);
+  if (_vw->audit)
+  {
+    _vw->audit_buffer->clear();
+    VW::read_line_json_s<true>(*_vw, examples, &line_vec[0], line_vec.size(), get_or_create_example_f, this);
+  }
+  else
+  {
+    VW::read_line_json_s<false>(*_vw, examples, &line_vec[0], line_vec.size(), get_or_create_example_f, this);
+  }
 
   // In order to control the seed for the sampling of each slot the event id + app id is passed in as the seed using the
   // example tag.
@@ -223,7 +266,16 @@ void safe_vw::rank_multi_slot_decisions(const char* event_id, const std::vector<
   // copy due to destructive parsing by rapidjson
   std::string line_vec(context);
 
-  VW::read_line_json_s<false>(*_vw, examples, &line_vec[0], line_vec.size(), get_or_create_example_f, this);
+  if (_vw->audit)
+  {
+    _vw->audit_buffer->clear();
+    VW::read_line_json_s<true>(*_vw, examples, &line_vec[0], line_vec.size(), get_or_create_example_f, this);
+  }
+  else
+  {
+    VW::read_line_json_s<false>(*_vw, examples, &line_vec[0], line_vec.size(), get_or_create_example_f, this);
+  }
+
   // In order to control the seed for the sampling of each slot the event id + app id is passed in as the seed using the
   // example tag.
   for (uint32_t i = 0; i < slot_ids.size(); i++)
@@ -316,6 +368,26 @@ bool safe_vw::is_CB_to_CCB_model_upgrade(const std::string& args) const
   const auto inbound_model_type = get_model_type(_vw->options.get());
 
   return local_model_type == mm::model_type_t::CCB && inbound_model_type == mm::model_type_t::CB;
+}
+
+const char* safe_vw::get_audit_data() const 
+{ 
+  if (_vw->audit)
+  { 
+    return &(*(_vw->audit_buffer))[0];
+  }
+  else
+  { 
+    return nullptr;
+  }
+}
+
+void safe_vw::init()
+{
+  if (_vw->audit) {
+    _vw->audit_buffer = std::make_shared<std::vector<char>>();
+    _vw->audit_writer = VW::io::create_vector_writer(_vw->audit_buffer);
+  }
 }
 
 safe_vw_factory::safe_vw_factory(std::string command_line) : _command_line(std::move(command_line)) {}

--- a/rlclientlib/vw_model/safe_vw.cc
+++ b/rlclientlib/vw_model/safe_vw.cc
@@ -371,7 +371,8 @@ string_view safe_vw::get_audit_data() const
 {
   if (_vw->audit) { return string_view(_vw->audit_buffer->data(), _vw->audit_buffer->size()); }
   else
-  { return string_view();
+  {
+    return string_view();
   }
 }
 

--- a/rlclientlib/vw_model/safe_vw.h
+++ b/rlclientlib/vw_model/safe_vw.h
@@ -40,11 +40,15 @@ public:
 
   bool is_compatible(const std::string& args) const;
   bool is_CB_to_CCB_model_upgrade(const std::string& args) const;
+  const char* get_audit_data() const;
 
   static model_management::model_type_t get_model_type(const std::string& args);
   static model_management::model_type_t get_model_type(const VW::config::options_i* args);
 
   friend class safe_vw_factory;
+
+private:
+  void init();
 };
 
 class safe_vw_factory

--- a/rlclientlib/vw_model/safe_vw.h
+++ b/rlclientlib/vw_model/safe_vw.h
@@ -40,7 +40,7 @@ public:
 
   bool is_compatible(const std::string& args) const;
   bool is_CB_to_CCB_model_upgrade(const std::string& args) const;
-  
+
   // audit data is not guaranteed after any subsequent safe_vw calls
   string_view get_audit_data() const;
 

--- a/rlclientlib/vw_model/safe_vw.h
+++ b/rlclientlib/vw_model/safe_vw.h
@@ -40,7 +40,9 @@ public:
 
   bool is_compatible(const std::string& args) const;
   bool is_CB_to_CCB_model_upgrade(const std::string& args) const;
-  const char* get_audit_data() const;
+  
+  // audit data is not guaranteed after any subsequent safe_vw calls
+  string_view get_audit_data() const;
 
   static model_management::model_type_t get_model_type(const std::string& args);
   static model_management::model_type_t get_model_type(const VW::config::options_i* args);

--- a/rlclientlib/vw_model/vw_model.cc
+++ b/rlclientlib/vw_model/vw_model.cc
@@ -188,7 +188,7 @@ void vw_model::write_audit_log(const char* event_id, string_view audit_buffer) c
     std::string filename(event_id);
     auto it = std::remove_if(filename.begin(), filename.end(), [](char const& c) { return !std::isalnum(c); });
     filename.erase(it, filename.end());
-	
+
     std::ostringstream filepath;
     filepath << _audit_output_path << reinforcement_learning::PATH_DELIMITER << filename;
 

--- a/rlclientlib/vw_model/vw_model.cc
+++ b/rlclientlib/vw_model/vw_model.cc
@@ -182,7 +182,7 @@ std::string vw_model::add_optional_audit_flag(const std::string& command_line) c
 
 void vw_model::write_audit_log(const char* event_id, string_view audit_buffer) const
 {
-  if (event_id != nullptr && audit_buffer != nullptr)
+  if (event_id != nullptr && audit_buffer.size() > 0)
   {
     // remove any non-alphanumeric characters from the output name
     std::string filename(event_id);

--- a/rlclientlib/vw_model/vw_model.cc
+++ b/rlclientlib/vw_model/vw_model.cc
@@ -182,7 +182,7 @@ std::string vw_model::add_optional_audit_flag(const std::string& command_line) c
 
 void vw_model::write_audit_log(const char* event_id, string_view audit_buffer) const
 {
-  if (event_id != nullptr && audit_buffer.size() > 0)
+  if (event_id != nullptr && !audit_buffer.empty())
   {
     // remove any non-alphanumeric characters from the output name
     std::string filename(event_id);

--- a/rlclientlib/vw_model/vw_model.cc
+++ b/rlclientlib/vw_model/vw_model.cc
@@ -173,22 +173,28 @@ int vw_model::request_multi_slot_decision(const char* event_id, const std::vecto
   }
 }
 
-const std::string vw_model::add_optional_audit_flag(const std::string& command_line) const
+std::string vw_model::add_optional_audit_flag(const std::string& command_line) const
 {
   if (_audit) { return command_line + " --audit"; }
 
   return command_line;
 }
 
-void vw_model::write_audit_log(const char* event_id, const char* audit_buffer) const
+void vw_model::write_audit_log(const char* event_id, string_view audit_buffer) const
 {
   if (event_id != nullptr && audit_buffer != nullptr)
   {
-    std::string filename = _audit_output_path + reinforcement_learning::delimiter + std::string(event_id);
+    // remove any non-alphanumeric characters from the output name
+    std::string filename(event_id);
+    auto it = std::remove_if(filename.begin(), filename.end(), [](char const& c) { return !std::isalnum(c); });
+    filename.erase(it, filename.end());
+	
+    std::ostringstream filepath;
+    filepath << _audit_output_path << reinforcement_learning::PATH_DELIMITER << filename;
 
     std::ofstream auditFile;
-    auditFile.open(filename, std::ofstream::out | std::ofstream::trunc);
-    auditFile.write(audit_buffer, strlen(audit_buffer));
+    auditFile.open(filepath.str(), std::ofstream::out | std::ofstream::trunc);
+    auditFile.write(audit_buffer.begin(), audit_buffer.size());
     auditFile.close();
   }
 }

--- a/rlclientlib/vw_model/vw_model.cc
+++ b/rlclientlib/vw_model/vw_model.cc
@@ -186,7 +186,7 @@ void vw_model::write_audit_log(const char* event_id, string_view audit_buffer) c
   {
     // remove any non-alphanumeric characters from the output name
     std::string filename(event_id);
-    auto it = std::remove_if(filename.begin(), filename.end(), [](char const& c) { return !std::isalnum(c); });
+    auto it = std::remove_if(filename.begin(), filename.end(), [](char const& c) { return !isalnum(c); });
     filename.erase(it, filename.end());
 
     std::ostringstream filepath;

--- a/rlclientlib/vw_model/vw_model.cc
+++ b/rlclientlib/vw_model/vw_model.cc
@@ -32,14 +32,11 @@ int vw_model::update(const model_data& data, bool& model_ready, api_status* stat
 
     if (data.data_sz() > 0)
     {
-      std::string cmd_line = add_optional_audit_flag(_quiet_commandline_options); 
+      std::string cmd_line = add_optional_audit_flag(_quiet_commandline_options);
 
-      std::unique_ptr<safe_vw> init_vw(
-          new safe_vw(data.data(), data.data_sz(), cmd_line));
+      std::unique_ptr<safe_vw> init_vw(new safe_vw(data.data(), data.data_sz(), cmd_line));
       if (init_vw->is_CB_to_CCB_model_upgrade(_initial_command_line))
-      {
-        cmd_line = add_optional_audit_flag(_upgrade_to_CCB_vw_commandline_options);
-      }
+      { cmd_line = add_optional_audit_flag(_upgrade_to_CCB_vw_commandline_options); }
 
       safe_vw_factory factory(data, cmd_line);
       std::unique_ptr<safe_vw> test_vw(factory());
@@ -78,10 +75,7 @@ int vw_model::choose_rank(const char* event_id, uint64_t rnd_seed, string_view f
     // Get a ranked list of action_ids and corresponding pdf
     vw->rank(features, action_ids, action_pdf);
 
-    if (_audit)
-    {
-      write_audit_log(event_id, vw->get_audit_data());
-    }
+    if (_audit) { write_audit_log(event_id, vw->get_audit_data()); }
 
     model_version = vw->id();
 
@@ -97,8 +91,9 @@ int vw_model::choose_rank(const char* event_id, uint64_t rnd_seed, string_view f
   }
 }
 
-int vw_model::choose_rank_multistep(const char* event_id, uint64_t rnd_seed, string_view features, const episode_history& history,
-    std::vector<int>& action_ids, std::vector<float>& action_pdf, std::string& model_version, api_status* status)
+int vw_model::choose_rank_multistep(const char* event_id, uint64_t rnd_seed, string_view features,
+    const episode_history& history, std::vector<int>& action_ids, std::vector<float>& action_pdf,
+    std::string& model_version, api_status* status)
 {
   return choose_rank(event_id, rnd_seed, features, action_ids, action_pdf, model_version, status);
 }
@@ -162,10 +157,7 @@ int vw_model::request_multi_slot_decision(const char* event_id, const std::vecto
     // Get a ranked list of action_ids and corresponding pdf
     vw->rank_multi_slot_decisions(event_id, slot_ids, features, actions_ids, action_pdfs);
 
-    if (_audit)
-    {
-      write_audit_log(event_id, vw->get_audit_data());
-    }
+    if (_audit) { write_audit_log(event_id, vw->get_audit_data()); }
 
     model_version = vw->id();
 
@@ -183,10 +175,7 @@ int vw_model::request_multi_slot_decision(const char* event_id, const std::vecto
 
 const std::string vw_model::add_optional_audit_flag(const std::string& command_line) const
 {
-  if (_audit)
-  {
-    return command_line + " --audit";
-  }
+  if (_audit) { return command_line + " --audit"; }
 
   return command_line;
 }
@@ -197,10 +186,10 @@ void vw_model::write_audit_log(const char* event_id, const char* audit_buffer) c
   {
     std::string filename = _audit_output_path + reinforcement_learning::delimiter + std::string(event_id);
 
-	std::ofstream auditFile;
-	auditFile.open(filename, std::ofstream::out | std::ofstream::trunc);
-	auditFile.write(audit_buffer, strlen(audit_buffer));
-	auditFile.close();
+    std::ofstream auditFile;
+    auditFile.open(filename, std::ofstream::out | std::ofstream::trunc);
+    auditFile.write(audit_buffer, strlen(audit_buffer));
+    auditFile.close();
   }
 }
 

--- a/rlclientlib/vw_model/vw_model.h
+++ b/rlclientlib/vw_model/vw_model.h
@@ -26,8 +26,8 @@ public:
   vw_model(i_trace* trace_logger, const utility::configuration& config);
 
   int update(const model_data& data, bool& model_ready, api_status* status = nullptr) override;
-  int choose_rank(const char* event_id, uint64_t rnd_seed, string_view features, std::vector<int>& action_ids, std::vector<float>& action_pdf,
-      std::string& model_version, api_status* status = nullptr) override;
+  int choose_rank(const char* event_id, uint64_t rnd_seed, string_view features, std::vector<int>& action_ids,
+      std::vector<float>& action_pdf, std::string& model_version, api_status* status = nullptr) override;
   int choose_continuous_action(string_view features, float& action, float& pdf_value, std::string& model_version,
       api_status* status = nullptr) override;
   int request_decision(const std::vector<const char*>& event_ids, string_view features,
@@ -36,9 +36,9 @@ public:
   int request_multi_slot_decision(const char* event_id, const std::vector<std::string>& slot_ids, string_view features,
       std::vector<std::vector<uint32_t>>& actions_ids, std::vector<std::vector<float>>& action_pdfs,
       std::string& model_version, api_status* status = nullptr) override;
-  int choose_rank_multistep(const char* event_id, uint64_t rnd_seed, string_view features, const episode_history& history,
-      std::vector<int>& action_ids, std::vector<float>& action_pdf, std::string& model_version,
-      api_status* status = nullptr) override;
+  int choose_rank_multistep(const char* event_id, uint64_t rnd_seed, string_view features,
+      const episode_history& history, std::vector<int>& action_ids, std::vector<float>& action_pdf,
+      std::string& model_version, api_status* status = nullptr) override;
   model_type_t model_type() const override;
 
 private:

--- a/rlclientlib/vw_model/vw_model.h
+++ b/rlclientlib/vw_model/vw_model.h
@@ -19,8 +19,8 @@ namespace model_management
 {
 class vw_model : public i_model
 {
-  const std::string add_optional_audit_flag(const std::string& command_line) const;
-  void write_audit_log(const char* event_id, const char* audit_buffer) const;
+  std::string add_optional_audit_flag(const std::string& command_line) const;
+  void write_audit_log(const char* event_id, string_view audit_buffer) const;
 
 public:
   vw_model(i_trace* trace_logger, const utility::configuration& config);

--- a/rlclientlib/vw_model/vw_model.h
+++ b/rlclientlib/vw_model/vw_model.h
@@ -19,11 +19,14 @@ namespace model_management
 {
 class vw_model : public i_model
 {
+  const std::string add_optional_audit_flag(const std::string& command_line) const;
+  void write_audit_log(const char* event_id, const char* audit_buffer) const;
+
 public:
   vw_model(i_trace* trace_logger, const utility::configuration& config);
 
   int update(const model_data& data, bool& model_ready, api_status* status = nullptr) override;
-  int choose_rank(uint64_t rnd_seed, string_view features, std::vector<int>& action_ids, std::vector<float>& action_pdf,
+  int choose_rank(const char* event_id, uint64_t rnd_seed, string_view features, std::vector<int>& action_ids, std::vector<float>& action_pdf,
       std::string& model_version, api_status* status = nullptr) override;
   int choose_continuous_action(string_view features, float& action, float& pdf_value, std::string& model_version,
       api_status* status = nullptr) override;
@@ -33,13 +36,16 @@ public:
   int request_multi_slot_decision(const char* event_id, const std::vector<std::string>& slot_ids, string_view features,
       std::vector<std::vector<uint32_t>>& actions_ids, std::vector<std::vector<float>>& action_pdfs,
       std::string& model_version, api_status* status = nullptr) override;
-  int choose_rank_multistep(uint64_t rnd_seed, string_view features, const episode_history& history,
+  int choose_rank_multistep(const char* event_id, uint64_t rnd_seed, string_view features, const episode_history& history,
       std::vector<int>& action_ids, std::vector<float>& action_pdf, std::string& model_version,
       api_status* status = nullptr) override;
   model_type_t model_type() const override;
 
 private:
+  const bool _audit;
+  const std::string _audit_output_path;
   const std::string _initial_command_line;
+  const std::string _quiet_commandline_options{"--json --quiet"};
   const std::string _upgrade_to_CCB_vw_commandline_options{"--ccb_explore_adf --json --quiet"};
   utility::versioned_object_pool<safe_vw> _vw_pool;
   i_trace* _trace_logger;

--- a/unit_test/mock_util.cc
+++ b/unit_test/mock_util.cc
@@ -68,7 +68,7 @@ std::unique_ptr<fakeit::Mock<m::i_model>> get_mock_model(m::model_type_t model_t
 {
   auto mock = std::unique_ptr<Mock<m::i_model>>(new fakeit::Mock<m::i_model>());
 
-  const auto choose_rank_fn = [](uint64_t, r::string_view, std::vector<int>&, std::vector<float>&,
+  const auto choose_rank_fn = [](const char*, uint64_t, r::string_view, std::vector<int>&, std::vector<float>&,
                                   std::string& model_version, r::api_status*) {
     model_version = "model_id";
     return r::error_code::success;
@@ -94,7 +94,7 @@ std::unique_ptr<fakeit::Mock<m::i_model>> get_mock_model(m::model_type_t model_t
     return r::error_code::success;
   };
 
-  const auto choose_rank_multistep_fn = [](uint64_t, r::string_view, const r::episode_history&, std::vector<int>&,
+  const auto choose_rank_multistep_fn = [](const char*, uint64_t, r::string_view, const r::episode_history&, std::vector<int>&,
                                             std::vector<float>&, std::string& model_version, r::api_status*) {
     model_version = "model_id";
     return r::error_code::success;

--- a/unit_test/mock_util.cc
+++ b/unit_test/mock_util.cc
@@ -94,8 +94,9 @@ std::unique_ptr<fakeit::Mock<m::i_model>> get_mock_model(m::model_type_t model_t
     return r::error_code::success;
   };
 
-  const auto choose_rank_multistep_fn = [](const char*, uint64_t, r::string_view, const r::episode_history&, std::vector<int>&,
-                                            std::vector<float>&, std::string& model_version, r::api_status*) {
+  const auto choose_rank_multistep_fn = [](const char*, uint64_t, r::string_view, const r::episode_history&,
+                                            std::vector<int>&, std::vector<float>&, std::string& model_version,
+                                            r::api_status*) {
     model_version = "model_id";
     return r::error_code::success;
   };

--- a/unit_test/safe_vw_test.cc
+++ b/unit_test/safe_vw_test.cc
@@ -33,6 +33,23 @@ BOOST_AUTO_TEST_CASE(safe_vw_1)
   BOOST_CHECK_EQUAL_COLLECTIONS(ranking.begin(), ranking.end(), ranking_expected.begin(), ranking_expected.end());
 }
 
+BOOST_AUTO_TEST_CASE(safe_vw_audit_logs)
+{
+  safe_vw vw((const char*)cb_data_5_model, cb_data_5_model_len, "--json --audit");
+  const auto json = R"({"a":{"0":1,"5":2},"_multi":[{"b":{"0":1}},{"b":{"0":2}},{"b":{"0":3}}]})";
+
+  std::vector<int> actions;
+  std::vector<float> ranking;
+  vw.rank(json, actions, ranking);
+
+  BOOST_CHECK_EQUAL(0, vw.get_audit_data().size());
+
+  safe_vw vw_w_audit((const char*)cb_data_5_model, cb_data_5_model_len, "--json --audit");
+  vw_w_audit.rank(json, actions, ranking);
+
+  BOOST_CHECK_GT(0, vw_w_audit.get_audit_data().size());
+}
+
 BOOST_AUTO_TEST_CASE(factory_with_cb_model_and_ccb_arguments)
 {
   const auto json =

--- a/unit_test/safe_vw_test.cc
+++ b/unit_test/safe_vw_test.cc
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(safe_vw_audit_logs)
   safe_vw vw_w_audit((const char*)cb_data_5_model, cb_data_5_model_len, "--json --audit");
   vw_w_audit.rank(json, actions, ranking);
 
-  BOOST_CHECK_GT(0, vw_w_audit.get_audit_data().size());
+  BOOST_CHECK_LT(0, vw_w_audit.get_audit_data().size());
 }
 
 BOOST_AUTO_TEST_CASE(factory_with_cb_model_and_ccb_arguments)

--- a/unit_test/safe_vw_test.cc
+++ b/unit_test/safe_vw_test.cc
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE(safe_vw_1)
 
 BOOST_AUTO_TEST_CASE(safe_vw_audit_logs)
 {
-  safe_vw vw((const char*)cb_data_5_model, cb_data_5_model_len, "--json --audit");
+  safe_vw vw((const char*)cb_data_5_model, cb_data_5_model_len, "--json --quiet");
   const auto json = R"({"a":{"0":1,"5":2},"_multi":[{"b":{"0":1}},{"b":{"0":2}},{"b":{"0":3}}]})";
 
   std::vector<int> actions;


### PR DESCRIPTION
Add the ability to specify audit output in the client configuration. When the AuditEnabled property is set to true, all audit output will be written to an audit file located at "{AUDIT_OUTPUT_PATH}/{eventId}". It is up to the caller to consume this output.

File IO was used to prevent changes to rlclientlib DLL surface. 

Bulk of changes are in vw_model as the audit is vw specific. Previously the vw model forcibly preventing any audit output during json parsing.