### PR TITLE
refactor: Update variable names in api_status.h to fix clang-tidy issues

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,6 +6,10 @@
     {
       "key": "performance-move-const-arg.CheckTriviallyCopyableMove",
       "value": "0"
+    },
+    {
+      "key":"readability-identifier-length.IgnoredVariableNames",
+      "value": "t"
     }
   ]
 }


### PR DESCRIPTION
Clang tidy warns when there are variable names shorter than 3 characters.