### PR TITLE
chore: ignore deprecated usages in test code to reduce noise

### DIFF
--- a/examples/basic_usage_cpp/basic_usage_cpp.cc
+++ b/examples/basic_usage_cpp/basic_usage_cpp.cc
@@ -126,11 +126,13 @@ int basic_usage_ca()
   // Response class
   r::continuous_action_response response;
 
+  RL_IGNORE_DEPRECATED_USAGE_START
   if (rl.request_continuous_action(event_id, context, response, &status) != err::success)
   {
     std::cout << status.get_error_msg() << std::endl;
     return -1;
   }
+  RL_IGNORE_DEPRECATED_USAGE_END
   //! [(3) Choose a continuous action]
 
   //! [(4) Use the response]
@@ -188,11 +190,13 @@ int basic_usage_ccb()
   // Response class
   r::decision_response response;
 
+  RL_IGNORE_DEPRECATED_USAGE_START
   if (rl.request_decision(context, response, &status) != err::success)
   {
     std::cout << status.get_error_msg() << std::endl;
     return -1;
   }
+  RL_IGNORE_DEPRECATED_USAGE_END
   //! [(3) Choose an action]
 
   //! [(4) Use the response / report outcome]
@@ -244,11 +248,13 @@ int basic_usage_slates()
   // Response class
   r::multi_slot_response response;
 
+  RL_IGNORE_DEPRECATED_USAGE_START
   if (rl.request_multi_slot_decision("event_id", context, response, &status) != err::success)
   {
     std::cout << status.get_error_msg() << std::endl;
     return -1;
   }
+  RL_IGNORE_DEPRECATED_USAGE_END
   //! [(3) Choose an action]
 
   //! [(4) Use the response]

--- a/examples/rl_sim_cpp/rl_sim.cc
+++ b/examples/rl_sim_cpp/rl_sim.cc
@@ -180,11 +180,13 @@ int rl_sim::ca_loop()
     const auto req_id = create_event_id();
     r::api_status status;
 
+    RL_IGNORE_DEPRECATED_USAGE_START
     if (_rl->request_continuous_action(req_id.c_str(), context_json, response, &status) != err::success)
     {
       std::cout << status.get_error_msg() << std::endl;
       continue;
     }
+    RL_IGNORE_DEPRECATED_USAGE_END
     const auto chosen_action = response.get_chosen_action();
     const auto outcome = joint.get_outcome(chosen_action, _random_seed);
     if (_rl->report_outcome(req_id.c_str(), outcome, &status) != err::success && outcome > 0.00001f)
@@ -221,11 +223,13 @@ int rl_sim::ccb_loop()
     r::api_status status;
 
     // Choose an action
+    RL_IGNORE_DEPRECATED_USAGE_START
     if (_rl->request_multi_slot_decision(event_id.c_str(), context_json, decision, &status) != err::success)
     {
       std::cout << status.get_error_msg() << std::endl;
       continue;
     }
+    RL_IGNORE_DEPRECATED_USAGE_END
 
     auto index = 0;
     for (auto& response : decision)
@@ -286,11 +290,13 @@ int rl_sim::slates_loop()
     r::api_status status;
 
     // Choose an action
+    RL_IGNORE_DEPRECATED_USAGE_START
     if (_rl->request_multi_slot_decision(event_id.c_str(), context_json.c_str(), decision, &status) != err::success)
     {
       std::cout << status.get_error_msg() << std::endl;
       continue;
     }
+    RL_IGNORE_DEPRECATED_USAGE_END
 
     float outcome = 0;
     int index = 0;

--- a/examples/test_cpp/test_loop.cc
+++ b/examples/test_cpp/test_loop.cc
@@ -205,11 +205,13 @@ void test_loop::ccb_loop(size_t thread_id) const
     const auto event_ids_c = to_const_char(event_ids);
     const std::string warmup_id = "_warmup_" + std::string(event_ids[0]);
     const auto context = test_inputs.get_context(0, 0, event_ids);
+    RL_IGNORE_DEPRECATED_USAGE_START
     if (rl->request_decision(context.c_str(), response, &status) != err::success)
     {
       std::cout << "Warmup is failed. " << status.get_error_msg() << std::endl;
       return;
     }
+    RL_IGNORE_DEPRECATED_USAGE_END
 
     r::utility::data_buffer buffer;
     r::logger::fb_collection_serializer<r::decision_ranking_event> serializer(
@@ -238,11 +240,13 @@ void test_loop::ccb_loop(size_t thread_id) const
     const auto event_ids = test_inputs.create_event_ids(thread_id, example_id);
     const auto event_ids_c = to_const_char(event_ids);
     const auto context = test_inputs.get_context(thread_id, example_id, event_ids);
+    RL_IGNORE_DEPRECATED_USAGE_START
     if (rl->request_decision(context.c_str(), response, &status) != err::success)
     {
       std::cout << status.get_error_msg() << std::endl;
       continue;
     }
+    RL_IGNORE_DEPRECATED_USAGE_END
 
     if (test_inputs.is_rewarded(thread_id, example_id))
     {

--- a/test_tools/example_gen/example_gen.cc
+++ b/test_tools/example_gen/example_gen.cc
@@ -283,30 +283,38 @@ int take_action(r::live_model& rl, const char* event_id, int action, unsigned in
     case CCB_ACTION:
     {  // "ccb",
       r::multi_slot_response response;
+      RL_IGNORE_DEPRECATED_USAGE_START
       if (rl.request_multi_slot_decision(event_id, JSON_CCB_CONTEXT, action_flag, response, &status) != err::success)
       { std::cout << status.get_error_msg() << std::endl; }
+      RL_IGNORE_DEPRECATED_USAGE_END
       break;
     };
     case CCB_WITH_SLOT_ID_ACTION:
     {  // "ccb-with-slot-id",
       r::multi_slot_response response;
+      RL_IGNORE_DEPRECATED_USAGE_START
       if (rl.request_multi_slot_decision(event_id, JSON_CCB_WITH_SLOT_ID_CONTEXT, action_flag, response, &status) !=
           err::success)
       { std::cout << status.get_error_msg() << std::endl; }
+      RL_IGNORE_DEPRECATED_USAGE_END
       break;
     };
     case SLATES_ACTION:
     {  // "slates",
       r::multi_slot_response response;
+      RL_IGNORE_DEPRECATED_USAGE_START
       if (rl.request_multi_slot_decision(event_id, JSON_SLATES_CONTEXT, action_flag, response, &status) != err::success)
       { std::cout << status.get_error_msg() << std::endl; }
+      RL_IGNORE_DEPRECATED_USAGE_END
       break;
     };
     case CA_ACTION:
     {  // "ca",
       r::continuous_action_response response;
+      RL_IGNORE_DEPRECATED_USAGE_START
       if (rl.request_continuous_action(event_id, JSON_CA_CONTEXT, action_flag, response, &status) != err::success)
       { std::cout << status.get_error_msg() << std::endl; }
+      RL_IGNORE_DEPRECATED_USAGE_END
       break;
     };
     case F_REWARD:  // "float"
@@ -388,9 +396,11 @@ int take_action(r::live_model& rl, const char* event_id, int action, unsigned in
     {  // "ccb",
       r::multi_slot_response response;
       std::vector<int> baselines{1, 0};
+      RL_IGNORE_DEPRECATED_USAGE_START
       if (rl.request_multi_slot_decision(event_id, JSON_CCB_CONTEXT, 0, response, baselines.data(), 2, &status) !=
           err::success)
       { std::cout << status.get_error_msg() << std::endl; }
+      RL_IGNORE_DEPRECATED_USAGE_END
       break;
     };
     case CB_LOOP:
@@ -426,8 +436,10 @@ int take_action(r::live_model& rl, const char* event_id, int action, unsigned in
     case CA_LOOP:
     {  // "ca_loop",
       r::continuous_action_response response;
+      RL_IGNORE_DEPRECATED_USAGE_START
       if (rl.request_continuous_action(event_id, JSON_CA_CONTEXT, action_flag, response, &status) != err::success)
       { std::cout << status.get_error_msg() << std::endl; }
+      RL_IGNORE_DEPRECATED_USAGE_END
       auto num_of_rewards = static_cast<size_t>(get_random_number(rng));
       for (size_t i = 0; i < num_of_rewards; i++)
       {
@@ -461,15 +473,19 @@ int take_action(r::live_model& rl, const char* event_id, int action, unsigned in
       if ((rand_number % 2) != 0u)
       {
         r::multi_slot_response response;
+        RL_IGNORE_DEPRECATED_USAGE_START
         if (rl.request_multi_slot_decision(event_id, JSON_CCB_CONTEXT, action_flag, response, &status) != err::success)
         { std::cout << status.get_error_msg() << std::endl; }
+        RL_IGNORE_DEPRECATED_USAGE_END
       }
       else
       {
         r::multi_slot_response response;
+        RL_IGNORE_DEPRECATED_USAGE_START
         if (rl.request_multi_slot_decision(event_id, JSON_CCB_WITH_SLOT_ID_CONTEXT, action_flag, response, &status) !=
             err::success)
         { std::cout << status.get_error_msg() << std::endl; }
+        RL_IGNORE_DEPRECATED_USAGE_END
       }
 
       send_ccb_outcome(rng, gen_random_reward, event_id, rl, status);
@@ -499,16 +515,20 @@ int take_action(r::live_model& rl, const char* event_id, int action, unsigned in
       if ((rand_number % 2) != 0u)
       {
         r::multi_slot_response response;
+        RL_IGNORE_DEPRECATED_USAGE_START
         if (rl.request_multi_slot_decision(
                 event_id, JSON_CCB_CONTEXT, action_flag, response, baselines.data(), 2, &status) != err::success)
         { std::cout << status.get_error_msg() << std::endl; }
+        RL_IGNORE_DEPRECATED_USAGE_END
       }
       else
       {
         r::multi_slot_response response;
+        RL_IGNORE_DEPRECATED_USAGE_START
         if (rl.request_multi_slot_decision(event_id, JSON_CCB_WITH_SLOT_ID_CONTEXT, action_flag, response,
                 baselines.data(), 2, &status) != err::success)
         { std::cout << status.get_error_msg() << std::endl; }
+        RL_IGNORE_DEPRECATED_USAGE_END
       }
 
       send_ccb_outcome(rng, gen_random_reward, event_id, rl, status);
@@ -531,8 +551,10 @@ int take_action(r::live_model& rl, const char* event_id, int action, unsigned in
     {  // "slates action and random number of float rewards"
       std::cout << "request multi-slot decision with baseline for event: " << event_id << std::endl;
       r::multi_slot_response response;
+      RL_IGNORE_DEPRECATED_USAGE_START
       if (rl.request_multi_slot_decision(event_id, JSON_SLATES_CONTEXT, action_flag, response, &status) != err::success)
       { std::cout << status.get_error_msg() << std::endl; }
+      RL_IGNORE_DEPRECATED_USAGE_END
 
       auto num_of_rewards = static_cast<size_t>(get_random_number(rng));
       for (size_t i = 0; i < num_of_rewards; i++)

--- a/unit_test/live_model_test.cc
+++ b/unit_test/live_model_test.cc
@@ -324,7 +324,9 @@ BOOST_AUTO_TEST_CASE(live_model_request_continuous_action)
 
   r::continuous_action_response response;
 
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(ds.request_continuous_action(JSON_CONTEXT_CONTINUOUS_ACTIONS, response, &status), err::success);
+  RL_IGNORE_DEPRECATED_USAGE_END
   // expected to fall in first unit range if no model exists
   BOOST_CHECK_GE(response.get_chosen_action(), min_value);
   BOOST_CHECK_LE(response.get_chosen_action(), min_value + unit_range);
@@ -363,8 +365,10 @@ BOOST_AUTO_TEST_CASE(live_model_request_continuous_action_invalid_ctx)
   r::continuous_action_response response;
 
   const auto invalid_context = "";
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(
       ds.request_continuous_action(invalid_context, response, &status), err::invalid_argument);  // invalid context
+  RL_IGNORE_DEPRECATED_USAGE_END
   BOOST_CHECK_EQUAL(status.get_error_code(), err::invalid_argument);
 }
 
@@ -386,19 +390,25 @@ BOOST_AUTO_TEST_CASE(live_model_request_decision)
   r::decision_response response;
 
   // request ranking
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(ds.request_decision(JSON_CONTEXT_WITH_SLOTS, response, &status), err::success);
+  RL_IGNORE_DEPRECATED_USAGE_END
   BOOST_CHECK_EQUAL(response.size(), 1);
   BOOST_CHECK_EQUAL((*response.begin()).get_action_id(), 0);
   BOOST_CHECK_EQUAL(status.get_error_code(), 0);
   BOOST_CHECK_EQUAL(status.get_error_msg(), "");
 
   const auto invalid_context = "";
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(ds.request_decision(invalid_context, response, &status), err::invalid_argument);  // invalid context
+  RL_IGNORE_DEPRECATED_USAGE_END
   BOOST_CHECK_EQUAL(status.get_error_code(), err::invalid_argument);
 
   const auto context_with_ids =
       R"({"GUser":{"hobby":"hiking","id":"a","major":"eng"},"_multi":[{"TAction":{"a1":"f1"}},{"TAction":{"a2":"f2"}}],"_slots":[{"TSlot":{"s1":"f1"},"_id":"817985e8-74ac-415c-bb69-735099c94d4d"},{"TSlot":{"s2":"f2"},"_id":"afb1da57-d4cd-4691-97d8-2b24bfb4e07f"}]})";
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(ds.request_decision(context_with_ids, response, &status), err::success);
+  RL_IGNORE_DEPRECATED_USAGE_END
   BOOST_CHECK_EQUAL(status.get_error_code(), 0);
   BOOST_CHECK_EQUAL(status.get_error_msg(), "");
   BOOST_CHECK_EQUAL(response.get_model_id(), "N/A");
@@ -979,7 +989,9 @@ BOOST_AUTO_TEST_CASE(ccb_explore_only_mode)
   BOOST_CHECK_EQUAL(model.init(&status), err::success);
 
   r::decision_response response;
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(model.request_decision(JSON_CCB_CONTEXT, response), err::success);
+  RL_IGNORE_DEPRECATED_USAGE_END
 
   BOOST_CHECK(strcmp(response.get_model_id(), "N/A") == 0);
   BOOST_CHECK_EQUAL(response.size(), 2);
@@ -1018,7 +1030,9 @@ BOOST_AUTO_TEST_CASE(multi_slot_response)
   BOOST_CHECK_EQUAL(model.init(&status), err::success);
 
   r::multi_slot_response response;
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(model.request_multi_slot_decision(JSON_CCB_CONTEXT, response), err::success);
+  RL_IGNORE_DEPRECATED_USAGE_END
 
   BOOST_CHECK(strcmp(response.get_model_id(), "N/A") == 0);
   BOOST_CHECK_EQUAL(response.size(), 2);
@@ -1057,7 +1071,9 @@ BOOST_AUTO_TEST_CASE(multi_slot_response_apprentice_mode_no_baseline)
   BOOST_CHECK_EQUAL(model.init(&status), err::success);
 
   r::multi_slot_response response;
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(model.request_multi_slot_decision(JSON_CCB_CONTEXT, response), err::baseline_actions_not_defined);
+  RL_IGNORE_DEPRECATED_USAGE_END
 }
 
 BOOST_AUTO_TEST_CASE(multi_slot_response_apprentice_mode_with_baseline)
@@ -1081,9 +1097,11 @@ BOOST_AUTO_TEST_CASE(multi_slot_response_apprentice_mode_with_baseline)
 
   r::multi_slot_response response;
   int baseline_actions[2] = {3, 1};
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(model.request_multi_slot_decision(
                         nullptr, JSON_CCB_CONTEXT, r::action_flags::DEFAULT, response, baseline_actions, 2),
       err::success);
+  RL_IGNORE_DEPRECATED_USAGE_END
 
   BOOST_CHECK(strcmp(response.get_model_id(), "N/A") == 0);
   BOOST_CHECK_EQUAL(response.size(), 2);
@@ -1127,9 +1145,11 @@ BOOST_AUTO_TEST_CASE(multi_slot_response_logging_only_with_baseline)
   // baseline actions are not valid action indicies, this is for testing purposes to make sure the action id is
   // overriden in apprentice / logginonly mode.
   int baseline_actions[2] = {3, 1};
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(model.request_multi_slot_decision(
                         nullptr, JSON_CCB_CONTEXT, r::action_flags::DEFAULT, response, baseline_actions, 2),
       err::success);
+  RL_IGNORE_DEPRECATED_USAGE_END
 
   BOOST_CHECK(strcmp(response.get_model_id(), "N/A") == 0);
   BOOST_CHECK_EQUAL(response.size(), 2);
@@ -1169,9 +1189,11 @@ BOOST_AUTO_TEST_CASE(multi_slot_response_logging_only_no_baseline)
   BOOST_CHECK_EQUAL(model.init(&status), err::success);
 
   r::multi_slot_response response;
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(
       model.request_multi_slot_decision(nullptr, JSON_CCB_CONTEXT, r::action_flags::DEFAULT, response, nullptr, 0),
       err::success);
+  RL_IGNORE_DEPRECATED_USAGE_END
 
   BOOST_CHECK(strcmp(response.get_model_id(), "N/A") == 0);
   BOOST_CHECK_EQUAL(response.size(), 2);
@@ -1212,9 +1234,11 @@ BOOST_AUTO_TEST_CASE(multi_slot_response_with_baseline_null_eventId)
 
   r::multi_slot_response response;
   int baseline_actions[2] = {3, 1};
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(model.request_multi_slot_decision(
                         nullptr, JSON_CCB_CONTEXT, r::action_flags::DEFAULT, response, baseline_actions, 2),
       err::success);
+  RL_IGNORE_DEPRECATED_USAGE_END
 
   BOOST_CHECK(strcmp(response.get_model_id(), "N/A") == 0);
   BOOST_CHECK_EQUAL(response.size(), 2);
@@ -1253,9 +1277,11 @@ BOOST_AUTO_TEST_CASE(multi_slot_response_with_baseline_custom_eventId)
 
   r::multi_slot_response response;
   int baseline_actions[2] = {3, 1};
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(model.request_multi_slot_decision(
                         "testEventId", JSON_CCB_CONTEXT, r::action_flags::DEFAULT, response, baseline_actions, 2),
       err::success);
+  RL_IGNORE_DEPRECATED_USAGE_END
 
   BOOST_CHECK(strcmp(response.get_model_id(), "N/A") == 0);
   BOOST_CHECK_EQUAL(response.size(), 2);
@@ -1294,7 +1320,9 @@ BOOST_AUTO_TEST_CASE(multi_slot_response_detailed)
   BOOST_CHECK_EQUAL(model.init(&status), err::success);
 
   r::multi_slot_response_detailed response;
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(model.request_multi_slot_decision(JSON_CCB_CONTEXT, response), err::success);
+  RL_IGNORE_DEPRECATED_USAGE_END
 
   BOOST_CHECK(strcmp(response.get_model_id(), "N/A") == 0);
   BOOST_CHECK_EQUAL(response.size(), 2);
@@ -1334,7 +1362,9 @@ BOOST_AUTO_TEST_CASE(multi_slot_response_detailed_apprentice_mode_no_baseline)
   BOOST_CHECK_EQUAL(model.init(&status), err::success);
 
   r::multi_slot_response_detailed response;
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(model.request_multi_slot_decision(JSON_CCB_CONTEXT, response), err::baseline_actions_not_defined);
+  RL_IGNORE_DEPRECATED_USAGE_END
 }
 
 BOOST_AUTO_TEST_CASE(multi_slot_response_detailed_apprentice_mode_with_baseline)
@@ -1358,9 +1388,11 @@ BOOST_AUTO_TEST_CASE(multi_slot_response_detailed_apprentice_mode_with_baseline)
 
   r::multi_slot_response_detailed response;
   int baseline_actions[2] = {3, 1};
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(model.request_multi_slot_decision(
                         nullptr, JSON_CCB_CONTEXT, r::action_flags::DEFAULT, response, baseline_actions, 2),
       err::success);
+  RL_IGNORE_DEPRECATED_USAGE_END
 
   BOOST_CHECK(strcmp(response.get_model_id(), "N/A") == 0);
   BOOST_CHECK_EQUAL(response.size(), 2);
@@ -1402,9 +1434,11 @@ BOOST_AUTO_TEST_CASE(multi_slot_response_detailed_logging_only_with_baseline)
 
   r::multi_slot_response_detailed response;
   int baseline_actions[2] = {3, 1};
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(model.request_multi_slot_decision(
                         nullptr, JSON_CCB_CONTEXT, r::action_flags::DEFAULT, response, baseline_actions, 2),
       err::success);
+  RL_IGNORE_DEPRECATED_USAGE_END
 
   BOOST_CHECK(strcmp(response.get_model_id(), "N/A") == 0);
   BOOST_CHECK_EQUAL(response.size(), 2);
@@ -1444,9 +1478,11 @@ BOOST_AUTO_TEST_CASE(multi_slot_response_detailed_logging_only_no_baseline)
   BOOST_CHECK_EQUAL(model.init(&status), err::success);
 
   r::multi_slot_response_detailed response;
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(
       model.request_multi_slot_decision(nullptr, JSON_CCB_CONTEXT, r::action_flags::DEFAULT, response, nullptr, 0),
       err::success);
+  RL_IGNORE_DEPRECATED_USAGE_END
 
   BOOST_CHECK(strcmp(response.get_model_id(), "N/A") == 0);
   BOOST_CHECK_EQUAL(response.size(), 2);
@@ -1487,9 +1523,11 @@ BOOST_AUTO_TEST_CASE(multi_slot_response_detailed_with_baseline_null_eventid)
 
   r::multi_slot_response_detailed response;
   int baseline_actions[2] = {3, 1};
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(model.request_multi_slot_decision(
                         nullptr, JSON_CCB_CONTEXT, r::action_flags::DEFAULT, response, baseline_actions, 2),
       err::success);
+  RL_IGNORE_DEPRECATED_USAGE_END
 
   BOOST_CHECK(strcmp(response.get_model_id(), "N/A") == 0);
   BOOST_CHECK_EQUAL(response.size(), 2);
@@ -1529,9 +1567,11 @@ BOOST_AUTO_TEST_CASE(multi_slot_response_detailed_with_baseline_custom_eventid)
 
   r::multi_slot_response_detailed response;
   int baseline_actions[2] = {3, 1};
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(model.request_multi_slot_decision(
                         "testEventId", JSON_CCB_CONTEXT, r::action_flags::DEFAULT, response, baseline_actions, 2),
       err::success);
+  RL_IGNORE_DEPRECATED_USAGE_END
 
   BOOST_CHECK(strcmp(response.get_model_id(), "N/A") == 0);
   BOOST_CHECK_EQUAL(response.size(), 2);
@@ -1573,7 +1613,9 @@ BOOST_AUTO_TEST_CASE(slates_explore_only_mode)
   BOOST_CHECK_EQUAL(model.init(&status), err::success);
 
   r::multi_slot_response response;
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(model.request_multi_slot_decision(JSON_SLATES_CONTEXT, response), err::success);
+  RL_IGNORE_DEPRECATED_USAGE_END
 
   BOOST_CHECK(strcmp(response.get_model_id(), "N/A") == 0);
   BOOST_CHECK_EQUAL(response.size(), 2);
@@ -1617,8 +1659,10 @@ BOOST_AUTO_TEST_CASE(live_model_ccb_and_v2)
   r::decision_response ccb_response;
 
   // slates API doesn't work for ccb under v1 protocol
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(ds.request_multi_slot_decision("event_id", JSON_CONTEXT_WITH_SLOTS, slates_response, &status),
       err::protocol_not_supported);
+  RL_IGNORE_DEPRECATED_USAGE_END
 
   config.set(r::name::PROTOCOL_VERSION, "2");
   r::live_model ds2 = create_mock_live_model(
@@ -1626,12 +1670,16 @@ BOOST_AUTO_TEST_CASE(live_model_ccb_and_v2)
   BOOST_CHECK_EQUAL(ds2.init(&status), err::success);
 
   // slates API work for ccb with v2
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(
       ds2.request_multi_slot_decision("event_id", JSON_CONTEXT_WITH_SLOTS, slates_response, &status), err::success);
+  RL_IGNORE_DEPRECATED_USAGE_END
   BOOST_CHECK_EQUAL(status.get_error_msg(), "");
 
   // old ccb api doesn't work under v2
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(ds2.request_decision(JSON_CONTEXT_WITH_SLOTS, ccb_response, &status), err::protocol_not_supported);
+  RL_IGNORE_DEPRECATED_USAGE_END
 }
 
 BOOST_AUTO_TEST_CASE(live_model_ccb_and_v2_w_slot_ids)
@@ -1653,9 +1701,11 @@ BOOST_AUTO_TEST_CASE(live_model_ccb_and_v2_w_slot_ids)
 
   r::multi_slot_response response;
 
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(
       ds.request_multi_slot_decision("event_id", JSON_CONTEXT_WITH_SLOTS_WITH_SLOT_IDS, response, &status),
       err::success);
+  RL_IGNORE_DEPRECATED_USAGE_END
   BOOST_CHECK_EQUAL(status.get_error_msg(), "");
 
   auto it = response.begin();
@@ -1689,9 +1739,11 @@ BOOST_AUTO_TEST_CASE(live_model_ccb_and_v2_w_slot_ids_and_slot_ns)
 
   r::multi_slot_response response;
 
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(
       ds.request_multi_slot_decision("event_id", JSON_CONTEXT_WITH_SLOTS_W_SLOT_IDS_AND_SLOT_NS, response, &status),
       err::success);
+  RL_IGNORE_DEPRECATED_USAGE_END
   BOOST_CHECK_EQUAL(status.get_error_msg(), "");
 
   auto it = response.begin();
@@ -1746,9 +1798,11 @@ BOOST_FIXTURE_TEST_CASE(live_model_ccb_and_v2_w_audit, AuditCleanup)
 
   // Add invalid path separators to the event_id
   std::string dirty_event_id = "../.." + event_id + "//\\..**";
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(ds.request_multi_slot_decision(
                         dirty_event_id.c_str(), JSON_CONTEXT_WITH_SLOTS_W_SLOT_IDS_AND_SLOT_NS, response, &status),
       err::success);
+  RL_IGNORE_DEPRECATED_USAGE_END
   BOOST_CHECK_EQUAL(status.get_error_msg(), "");
 
   std::ifstream audit_file;
@@ -1780,9 +1834,11 @@ BOOST_FIXTURE_TEST_CASE(live_model_ccb_and_v2_w_audit_bad_path, AuditCleanup)
 
   // Add invalid path separators to the event_id
   std::string dirty_event_id = "../.." + event_id + "//\\..**";
+  RL_IGNORE_DEPRECATED_USAGE_START
   BOOST_CHECK_EQUAL(ds.request_multi_slot_decision(
                         dirty_event_id.c_str(), JSON_CONTEXT_WITH_SLOTS_W_SLOT_IDS_AND_SLOT_NS, response, &status),
       err::success);
+  RL_IGNORE_DEPRECATED_USAGE_END
   BOOST_CHECK_EQUAL(status.get_error_msg(), "");
 
   std::ifstream audit_file;


### PR DESCRIPTION
When compiling these make it hard to see new issues introduced in a change. Wrapping them in ignores to prevent this issue.