### PR TITLE
force clone tags

### DIFF
--- a/.github/workflows/build_nuget.yml
+++ b/.github/workflows/build_nuget.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: ["windows-2019"]
         toolset: ["v141", "v142"]
-  
+
     steps:
       # Get repository and setup dependencies
       - uses: actions/checkout@v2
@@ -56,7 +56,7 @@ jobs:
       # Get version number
       - name: Update git tags
         # Needed because actions/checkout performs a shallow checkout without tags
-        run: git fetch --unshallow --tags --recurse-submodules=no
+        run: git fetch --unshallow --tags --recurse-submodules=no --force
       - name: Get version number
         id: get_version
         shell: bash
@@ -64,7 +64,7 @@ jobs:
           version=$(./.scripts/version_number.py)
           echo "Generated version number: $version"
           echo "::set-output name=version::$version"
-      
+
       # Compile code and create package
       - name: Configure
         run: >
@@ -127,7 +127,7 @@ jobs:
       # Get version number
       - name: Update git tags
         # Needed because actions/checkout performs a shallow checkout without tags
-        run: git fetch --unshallow --tags --recurse-submodules=no
+        run: git fetch --unshallow --tags --recurse-submodules=no --force
       - name: Get version number
         id: get_version
         shell: bash
@@ -135,7 +135,7 @@ jobs:
           version=$(./.scripts/version_number.py)
           echo "Generated version number: $version"
           echo "::set-output name=version::$version"
-      
+
       # Download and install nuget
       - uses: actions/download-artifact@v1
         with:
@@ -156,7 +156,7 @@ jobs:
         run: |
           cd nuget\test\packages
           mv * RLClientLibNativeStatic-${{ matrix.toolset }}-x64
-      
+
       # Compile and run
       - name: Build test
         run: |

--- a/.github/workflows/dotnet_nugets.yml
+++ b/.github/workflows/dotnet_nugets.yml
@@ -132,7 +132,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Update git tags
         # Needed because actions/checkout performs a shallow checkout without tags
-        run: git fetch --unshallow --tags --recurse-submodules=no
+        run: git fetch --unshallow --tags --recurse-submodules=no --force
 
       - name: Get version number
         shell: bash
@@ -166,7 +166,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Update git tags
         # Needed because actions/checkout performs a shallow checkout without tags
-        run: git fetch --unshallow --tags --recurse-submodules=no
+        run: git fetch --unshallow --tags --recurse-submodules=no --force
 
       - name: Get version number
         shell: bash

--- a/.scripts/version_number.py
+++ b/.scripts/version_number.py
@@ -14,7 +14,7 @@ git_shallow = subprocess.check_output(
 ).strip()
 if git_shallow != "false":
     debug_print("Error: Git repository is shallow!")
-    debug_print("To fix, run: 'git fetch --unshallow --tags --recurse-submodules=no'")
+    debug_print("To fix, run: 'git fetch --unshallow --tags --recurse-submodules=no --force'")
     sys.exit(1)
 
 git_describe = subprocess.check_output(

--- a/.scripts/version_number.py
+++ b/.scripts/version_number.py
@@ -14,7 +14,9 @@ git_shallow = subprocess.check_output(
 ).strip()
 if git_shallow != "false":
     debug_print("Error: Git repository is shallow!")
-    debug_print("To fix, run: 'git fetch --unshallow --tags --recurse-submodules=no --force'")
+    debug_print(
+        "To fix, run: 'git fetch --unshallow --tags --recurse-submodules=no --force'"
+    )
     sys.exit(1)
 
 git_describe = subprocess.check_output(


### PR DESCRIPTION
In response to issue on remote:

```
2022-11-07T14:18:33.0869855Z ##[group]Run git fetch --unshallow --tags --recurse-submodules=no
2022-11-07T14:18:33.0870298Z [36;1mgit fetch --unshallow --tags --recurse-submodules=no[0m
2022-11-07T14:18:33.0926050Z shell: /usr/bin/bash -e {0}
2022-11-07T14:18:33.0926294Z env:
2022-11-07T14:18:33.0926622Z   VCPKG_DEFAULT_BINARY_CACHE: /home/runner/work/reinforcement_learning/reinforcement_learning/vcpkg_binary_cache
2022-11-07T14:18:33.0926958Z ##[endgroup]
2022-11-07T14:18:34.7557257Z From https://github.com/VowpalWabbit/reinforcement_learning
2022-11-07T14:18:34.7558469Z  * [new branch]      ataymano/ci_fix         -> origin/ataymano/ci_fix
2022-11-07T14:18:34.7559537Z  * [new branch]      ataymano/dev            -> origin/ataymano/dev
2022-11-07T14:18:34.7561052Z  * [new branch]      ataymano/guided_proto   -> origin/ataymano/guided_proto
2022-11-07T14:18:34.7562361Z  * [new branch]      ataymano/invalid_flatbuff_fix -> origin/ataymano/invalid_flatbuff_fix
2022-11-07T14:18:34.7563489Z  * [new branch]      ataymano/macosxbuild    -> origin/ataymano/macosxbuild
2022-11-07T14:18:34.7564599Z  * [new branch]      ataymano/more_multistep_tests -> origin/ataymano/more_multistep_tests
2022-11-07T14:18:34.7565700Z  * [new branch]      ataymano/vw_update_012422 -> origin/ataymano/vw_update_012422
2022-11-07T14:18:34.7566745Z  * [new branch]      bassmang-patch-1        -> origin/bassmang-patch-1
2022-11-07T14:18:34.7567764Z  * [new branch]      build_on_tag            -> origin/build_on_tag
2022-11-07T14:18:34.7568777Z  * [new branch]      cb_ccb_hotfix           -> origin/cb_ccb_hotfix
2022-11-07T14:18:34.7569850Z  * [new branch]      cb_ccb_hotfix_w_logonly -> origin/cb_ccb_hotfix_w_logonly
2022-11-07T14:18:34.7570925Z  * [new branch]      ccb_hotfix              -> origin/ccb_hotfix
2022-11-07T14:18:34.7572029Z  * [new branch]      create_valgrind_pipeline -> origin/create_valgrind_pipeline
2022-11-07T14:18:34.7575545Z  * [new branch]      dependabot/nuget/bindings/cs/rl.net.cli/Newtonsoft.Json-13.0.1 -> origin/dependabot/nuget/bindings/cs/rl.net.cli/Newtonsoft.Json-13.0.1
2022-11-07T14:18:34.7576888Z  * [new branch]      dev/Fix-SenderFactoryRegisterationVisibility -> origin/dev/Fix-SenderFactoryRegisterationVisibility
2022-11-07T14:18:34.7577858Z  * [new branch]      dev/rlnet_nuget         -> origin/dev/rlnet_nuget
2022-11-07T14:18:34.7578902Z  * [new branch]      dotnet_changes          -> origin/dotnet_changes
2022-11-07T14:18:34.7580138Z  * [new branch]      dotnetchanges2          -> origin/dotnetchanges2
2022-11-07T14:18:34.7581394Z  * [new branch]      fast_opaque_experiment  -> origin/fast_opaque_experiment
2022-11-07T14:18:34.7582409Z  * [new branch]      fed_interfaces          -> origin/fed_interfaces
2022-11-07T14:18:34.7583503Z  * [new branch]      ignore_test_usage_deprecated -> origin/ignore_test_usage_deprecated
2022-11-07T14:18:34.7584491Z  * [new branch]      lalo-patch-2            -> origin/lalo-patch-2
2022-11-07T14:18:34.7585516Z  * [new branch]      local_client            -> origin/local_client
2022-11-07T14:18:34.7586585Z  * [new branch]      local_loop_prototype    -> origin/local_loop_prototype
2022-11-07T14:18:34.7587586Z  * [new branch]      master                  -> origin/master
2022-11-07T14:18:34.7588615Z  * [new branch]      multistep               -> origin/multistep
2022-11-07T14:18:34.7589614Z  * [new branch]      nuget                   -> origin/nuget
2022-11-07T14:18:34.7591158Z  * [new branch]      olgavrou/split_up_builds -> origin/olgavrou/split_up_builds
2022-11-07T14:18:34.7592284Z  * [new branch]      olgavrou/test_vw_fbs    -> origin/olgavrou/test_vw_fbs
2022-11-07T14:18:34.7593412Z  * [new branch]      olgavrou/valgrind_dont_suppress_errors -> origin/olgavrou/valgrind_dont_suppress_errors
2022-11-07T14:18:34.7595006Z  * [new branch]      ormichae/addActionProbabilityCCBResponse -> origin/ormichae/addActionProbabilityCCBResponse
2022-11-07T14:18:34.7596332Z  * [new branch]      ormichae/addBaselineActionsToMultiSlotDecision -> origin/ormichae/addBaselineActionsToMultiSlotDecision
2022-11-07T14:18:34.7597343Z  * [new branch]      ormichae/addStringSlotIdReportOutcomeBinding -> origin/ormichae/addStringSlotIdReportOutcomeBinding
2022-11-07T14:18:34.7598249Z  * [new branch]      ormichae/updatevw       -> origin/ormichae/updatevw
2022-11-07T14:18:34.7599309Z  * [new branch]      peterychang-patch-1     -> origin/peterychang-patch-1
2022-11-07T14:18:34.7600738Z  * [new branch]      rajan/rl_quad_hotfix    -> origin/rajan/rl_quad_hotfix
2022-11-07T14:18:34.7601792Z  * [new branch]      readme_vcpkg            -> origin/readme_vcpkg
2022-11-07T14:18:34.7602904Z  * [new branch]      revert-520-local_loop_prototype -> origin/revert-520-local_loop_prototype
2022-11-07T14:18:34.7603919Z  * [new branch]      rl-quad-interact-hotfix -> origin/rl-quad-interact-hotfix
2022-11-07T14:18:34.7604909Z  * [new branch]      update_openssl          -> origin/update_openssl
2022-11-07T14:18:34.7605947Z  * [new branch]      update_vw_w_fbs         -> origin/update_vw_w_fbs
2022-11-07T14:18:34.7606996Z  * [new branch]      upgrade_to_950          -> origin/upgrade_to_950
2022-11-07T14:18:34.7608071Z  * [new branch]      upvwrs                  -> origin/upvwrs
2022-11-07T14:18:34.7609122Z  * [new branch]      windows_pipeline        -> origin/windows_pipeline
2022-11-07T14:18:34.7609699Z  ! [rejected]        0.2.0                   -> 0.2.0  (would clobber existing tag)
```