### PR TITLE
Add C# binding to Episodic RL interface

### DIFF
--- a/bindings/cs/rl.net.native/rl.net.episode_state.cc
+++ b/bindings/cs/rl.net.native/rl.net.episode_state.cc
@@ -1,0 +1,18 @@
+#include "rl.net.episode_state.h"
+
+API reinforcement_learning::episode_state* CreateEpisodeState(const char* episodeId)
+{
+  return new reinforcement_learning::episode_state(episodeId);
+}
+
+API void DeleteEpisodeState(reinforcement_learning::episode_state* episode_state) { delete episode_state; }
+
+API const char* GetEpisodeId(reinforcement_learning::episode_state* episode_state) { return episode_state->get_episode_id(); }
+
+API int UpdateEpisodeHistory(reinforcement_learning::episode_state* episode_state, const char* event_id,
+    const char* previous_event_id, const char* context, reinforcement_learning::ranking_response& response,
+    reinforcement_learning::api_status* error)
+
+{
+  return episode_state->update(event_id, previous_event_id, context, response, error);
+}

--- a/bindings/cs/rl.net.native/rl.net.episode_state.cc
+++ b/bindings/cs/rl.net.native/rl.net.episode_state.cc
@@ -7,12 +7,13 @@ API reinforcement_learning::episode_state* CreateEpisodeState(const char* episod
 
 API void DeleteEpisodeState(reinforcement_learning::episode_state* episode_state) { delete episode_state; }
 
-API const char* GetEpisodeId(reinforcement_learning::episode_state* episode_state) { return episode_state->get_episode_id(); }
+API const char* GetEpisodeId(reinforcement_learning::episode_state* episode_state)
+{
+  return episode_state->get_episode_id();
+}
 
 API int UpdateEpisodeHistory(reinforcement_learning::episode_state* episode_state, const char* event_id,
-    const char* previous_event_id, const char* context, reinforcement_learning::ranking_response& response,
-    reinforcement_learning::api_status* error)
-
+    const char* previous_event_id, const char* context, reinforcement_learning::api_status* error)
 {
-  return episode_state->update(event_id, previous_event_id, context, response, error);
+  return episode_state->update(event_id, previous_event_id, context, error);
 }

--- a/bindings/cs/rl.net.native/rl.net.episode_state.h
+++ b/bindings/cs/rl.net.native/rl.net.episode_state.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include "rl.net.native.h"
-#include <ranking_response.h>
+
 #include <api_status.h>
+#include <ranking_response.h>
 
 // Global exports
 extern "C"
@@ -12,6 +13,6 @@ extern "C"
   API void DeleteEpisodeState(reinforcement_learning::episode_state* episode_state);
 
   API const char* GetEpisodeId(reinforcement_learning::episode_state* episode_state);
-  API int UpdateEpisodeHistory(reinforcement_learning::episode_state* episode_state, const char* event_id, const char* previous_event_id, const char* context,
-      reinforcement_learning::ranking_response& response, reinforcement_learning::api_status* error = nullptr);
+  API int UpdateEpisodeHistory(reinforcement_learning::episode_state* episode_state, const char* event_id,
+      const char* previous_event_id, const char* context, reinforcement_learning::api_status* error = nullptr);
 }

--- a/bindings/cs/rl.net.native/rl.net.episode_state.h
+++ b/bindings/cs/rl.net.native/rl.net.episode_state.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "rl.net.native.h"
+#include <ranking_response.h>
+#include <api_status.h>
+
+// Global exports
+extern "C"
+{
+  // NOTE: THIS IS NOT POLYMORPHISM SAFE!
+  API reinforcement_learning::episode_state* CreateEpisodeState(const char* episodeId);
+  API void DeleteEpisodeState(reinforcement_learning::episode_state* episode_state);
+
+  API const char* GetEpisodeId(reinforcement_learning::episode_state* episode_state);
+  API int UpdateEpisodeHistory(reinforcement_learning::episode_state* episode_state, const char* event_id, const char* previous_event_id, const char* context,
+      reinforcement_learning::ranking_response& response, reinforcement_learning::api_status* error = nullptr);
+}

--- a/bindings/cs/rl.net.native/rl.net.live_model.cc
+++ b/bindings/cs/rl.net.native/rl.net.live_model.cc
@@ -211,6 +211,25 @@ API int LiveModelRequestMultiSlotDecisionDetailedWithBaselineAndFlags(livemodel_
   RL_IGNORE_DEPRECATED_USAGE_END
 }
 
+API int LiveModelRequestEpisodicDecisionWithFlags(livemodel_context_t* context, const char* event_id, const char* previous_id,
+    const char* context_json, unsigned int flags, reinforcement_learning::ranking_response& resp,
+    reinforcement_learning:: episode_state& episode,
+    reinforcement_learning::api_status* status)
+{
+  RL_IGNORE_DEPRECATED_USAGE_START
+  return context->livemodel->request_episodic_decision(event_id, previous_id, context_json, flags, resp, episode, status);
+  RL_IGNORE_DEPRECATED_USAGE_END
+}
+
+API int LiveModelRequestEpisodicDecision(livemodel_context_t* context, const char* event_id, const char* previous_id,
+    const char* context_json, reinforcement_learning::ranking_response& resp,
+    reinforcement_learning::episode_state& episode, reinforcement_learning:: api_status* status)
+{
+  RL_IGNORE_DEPRECATED_USAGE_START
+  return context->livemodel->request_episodic_decision(event_id, previous_id, context_json, resp, episode, status);
+  RL_IGNORE_DEPRECATED_USAGE_END
+}
+
 API int LiveModelReportActionTaken(
     livemodel_context_t* context, const char* event_id, reinforcement_learning::api_status* status)
 {

--- a/bindings/cs/rl.net.native/rl.net.live_model.h
+++ b/bindings/cs/rl.net.native/rl.net.live_model.h
@@ -77,6 +77,10 @@ extern "C"
       const char* event_id, const char* context_json, int context_json_size, unsigned int flags,
       reinforcement_learning::multi_slot_response_detailed* resp, const int* baseline_actions,
       size_t baseline_actions_size, reinforcement_learning::api_status* status = nullptr);
+  API int LiveModelRequestEpisodicDecisionWithFlags(livemodel_context_t* context, const char* event_id,
+      const char* previous_id, const char* context_json, unsigned int flags,
+      reinforcement_learning::ranking_response& resp, reinforcement_learning::episode_state& episode,
+      reinforcement_learning::api_status* status);
 
   API int LiveModelReportActionTaken(
       livemodel_context_t* livemodel, const char* event_id, reinforcement_learning::api_status* status = nullptr);

--- a/bindings/cs/rl.net/EpisodeState.cs
+++ b/bindings/cs/rl.net/EpisodeState.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Runtime.InteropServices;
+
+using Rl.Net.Native;
+
+namespace Rl.Net
+{
+    namespace Native
+    {
+        internal partial class NativeMethods
+        {
+            [DllImport("rlnetnative")]
+            public static extern IntPtr CreateEpisodeState(IntPtr episodeId);
+
+            [DllImport("rlnetnative")]
+            public static extern void DeleteEpisodeState(IntPtr episodeState);
+
+            [DllImport("rlnetnative")]
+            public static extern IntPtr GetEpisodeId(IntPtr episodeState);
+
+            [DllImport("rlnetnative")]
+            public static extern int UpdateEpisodeHistory(IntPtr episodeState, string event_id, string previous_event_id, string context,
+            RankingResponse response, ApiStatus error = null);
+        }
+    }
+
+    public sealed class EpisodeState : NativeObject<EpisodeState>
+    {
+        public EpisodeState(string episodeId) : base(BindConstructorArguments(episodeId), new Delete<EpisodeState>(NativeMethods.DeleteEpisodeState))
+        {
+        }
+
+        internal EpisodeState(IntPtr sharedEpisodeStateHandle) : base(sharedEpisodeStateHandle, ownsHandle: false)
+        {
+        }
+
+        private static New<EpisodeState> BindConstructorArguments(string episodeId)
+        {
+            return new New<EpisodeState>(() =>
+            {
+                unsafe
+                {
+                    fixed (byte* episodeIdUtf8Bytes = NativeMethods.StringEncoding.GetBytes(episodeId))
+                    {
+                        IntPtr contextJsonUtf8Ptr = new IntPtr(episodeIdUtf8Bytes);
+                        IntPtr result = NativeMethods.CreateEpisodeState(contextJsonUtf8Ptr);
+                        GC.KeepAlive(episodeId);
+                        return result;
+                    }
+                }
+            });
+        }
+
+        public int Update(string eventId, string previousEventId, string context, RankingResponse response, ApiStatus status = null)
+        {
+            return NativeMethods.UpdateEpisodeHistory(this.DangerousGetHandle(), eventId, previousEventId, context, response, status);
+        }
+
+        public string EpisodeId
+        {
+            get
+            {
+                IntPtr episodeIdUtf8Ptr = NativeMethods.GetEpisodeId(this.DangerousGetHandle());
+                GC.KeepAlive(this);
+                return NativeMethods.StringMarshallingFunc(episodeIdUtf8Ptr);
+            }
+        }
+    }
+}

--- a/bindings/cs/rl.net/LiveModel.cs
+++ b/bindings/cs/rl.net/LiveModel.cs
@@ -1126,6 +1126,7 @@ namespace Rl.Net
         public bool TryRequestEpisodicDecision(string eventId, string previousEventId, string contextJson, ActionFlags flags, EpisodeState states, RankingResponse resp, ApiStatus apiStatus)
         {
             int result = LiveModelRequestEpisodicDecisionWithFlags(this.DangerousGetHandle(), eventId, previousEventId, contextJson, (uint)flags, resp.DangerousGetHandle(), states.DangerousGetHandle(), apiStatus.DangerousGetHandle());
+            Console.WriteLine("TryRequestEpisodicDecision result " + result);
             GC.KeepAlive(this);
             return result == NativeMethods.SuccessStatus;
         }
@@ -1137,6 +1138,7 @@ namespace Rl.Net
             using (ApiStatus apiStatus = new ApiStatus())
                 if (!this.TryRequestEpisodicDecision(eventId, previousEventId, contextJson, flags, states, resp, apiStatus))
                 {
+                    Console.WriteLine("api error" + apiStatus.ErrorMessage + apiStatus.ErrorCode);
                     throw new RLException(apiStatus);
                 }
             return resp;

--- a/bindings/cs/rl.net/LiveModel.cs
+++ b/bindings/cs/rl.net/LiveModel.cs
@@ -170,7 +170,7 @@ namespace Rl.Net
             }
 
             [DllImport("rlnetnative", EntryPoint = "LiveModelRequestMultiSlotDecisionDetailedWithFlags")]
-            private static extern int LiveModelRequestMultiSlotDecisionDetailedWithFlagsNative(IntPtr liveModel, IntPtr eventId, IntPtr contextJson,  int contextJsonSize, uint flags, IntPtr multiSlotResponseDetailed, IntPtr apiStatus);
+            private static extern int LiveModelRequestMultiSlotDecisionDetailedWithFlagsNative(IntPtr liveModel, IntPtr eventId, IntPtr contextJson, int contextJsonSize, uint flags, IntPtr multiSlotResponseDetailed, IntPtr apiStatus);
 
             internal static Func<IntPtr, IntPtr, IntPtr, int, uint, IntPtr, IntPtr, int> LiveModelRequestMultiSlotDecisionDetailedWithFlagsOverride { get; set; }
 
@@ -197,6 +197,36 @@ namespace Rl.Net
                 }
 
                 return LiveModelRequestMultiSlotDecisionDetailedWithBaselineAndFlagsNative(liveModel, eventId, contextJson, contextJsonSize, flags, multiSlotResponseDetailed, baselineActions, baselineActionsSize, apiStatus);
+            }
+
+            [DllImport("rlnetnative", EntryPoint = "LiveModelRequestEpisodicDecision")]
+            private static extern int LiveModelRequestEpisodicDecisionNative(IntPtr liveModel, IntPtr eventId, IntPtr previousEventId, IntPtr contextJson, IntPtr rankingResponse, IntPtr episodes, IntPtr apiStatus);
+
+            internal static Func<IntPtr, IntPtr, IntPtr, IntPtr, IntPtr, IntPtr, IntPtr, int> LiveModelRequestEpisodicDecisionOverride { get; set; }
+
+            public static int LiveModelRequestEpisodicDecision(IntPtr liveModel, IntPtr eventId, IntPtr previousEventId, IntPtr contextJson, IntPtr rankingResponse, IntPtr episodes, IntPtr apiStatus)
+            {
+                if (LiveModelRequestEpisodicDecisionOverride != null)
+                {
+                    return LiveModelRequestEpisodicDecisionOverride(liveModel, eventId, previousEventId, contextJson, rankingResponse, episodes, apiStatus);
+                }
+
+                return LiveModelRequestEpisodicDecisionNative(liveModel, eventId, previousEventId, contextJson, rankingResponse, episodes, apiStatus);
+            }
+
+            [DllImport("rlnetnative", EntryPoint = "LiveModelRequestEpisodicDecisionWithFlags")]
+            private static extern int LiveModelRequestEpisodicDecisionWithFlagsNative(IntPtr liveModel, IntPtr eventId, IntPtr previousEventId, IntPtr contextJson, uint flags, IntPtr rankingResponse, IntPtr episodes, IntPtr apiStatus);
+
+            internal static Func<IntPtr, IntPtr, IntPtr, IntPtr, uint, IntPtr, IntPtr, IntPtr, int> LiveModelRequestEpisodicDecisionWithFlagsOverride { get; set; }
+
+            public static int LiveModelRequestEpisodicDecisionWithFlags(IntPtr liveModel, IntPtr eventId, IntPtr previousEventId, IntPtr contextJson, uint flags, IntPtr rankingResponse, IntPtr episodes, IntPtr apiStatus)
+            {
+                if (LiveModelRequestEpisodicDecisionWithFlagsOverride != null)
+                {
+                    return LiveModelRequestEpisodicDecisionWithFlagsOverride(liveModel, eventId, previousEventId, contextJson, flags, rankingResponse, episodes, apiStatus);
+                }
+
+                return LiveModelRequestEpisodicDecisionWithFlagsNative(liveModel, eventId, previousEventId, contextJson, flags, rankingResponse, episodes, apiStatus);
             }
 
             [DllImport("rlnetnative", EntryPoint = "LiveModelReportActionTaken")]
@@ -343,7 +373,7 @@ namespace Rl.Net
         }
 
         public LiveModel(Configuration config) : this(config, null)
-        {}
+        { }
 
         public LiveModel(Configuration config, FactoryContext factoryContext) : base(BindConstructorArguments(config, factoryContext), new Delete<LiveModel>(NativeMethods.DeleteLiveModel))
         {
@@ -491,7 +521,7 @@ namespace Rl.Net
                     return NativeMethods.LiveModelRequestMultiSlotDecision(liveModel, IntPtr.Zero, (IntPtr)contextJsonUtf8Bytes, contextJsonSize, multiSlotResponse, apiStatus);
                 }
 
-                fixed(byte* eventIdUtf8Bytes = NativeMethods.StringEncoding.GetBytes(eventId))
+                fixed (byte* eventIdUtf8Bytes = NativeMethods.StringEncoding.GetBytes(eventId))
                 {
                     return NativeMethods.LiveModelRequestMultiSlotDecision(liveModel, (IntPtr)eventIdUtf8Bytes, (IntPtr)contextJsonUtf8Bytes, contextJsonSize, multiSlotResponse, apiStatus);
                 }
@@ -510,7 +540,7 @@ namespace Rl.Net
                     return NativeMethods.LiveModelRequestMultiSlotDecisionWithFlags(liveModel, IntPtr.Zero, (IntPtr)contextJsonUtf8Bytes, contextJsonSize, flags, multiSlotResponse, apiStatus);
                 }
 
-                fixed(byte* eventIdUtf8Bytes = NativeMethods.StringEncoding.GetBytes(eventId))
+                fixed (byte* eventIdUtf8Bytes = NativeMethods.StringEncoding.GetBytes(eventId))
                 {
                     return NativeMethods.LiveModelRequestMultiSlotDecisionWithFlags(liveModel, (IntPtr)eventIdUtf8Bytes, (IntPtr)contextJsonUtf8Bytes, contextJsonSize, flags, multiSlotResponse, apiStatus);
                 }
@@ -580,7 +610,7 @@ namespace Rl.Net
             CheckJsonString(contextJson);
 
             fixed (byte* contextJsonUtf8Bytes = NativeMethods.StringEncoding.GetBytes(contextJson))
-            fixed(int* baselineActionsFixed = baselineActions)
+            fixed (int* baselineActionsFixed = baselineActions)
             {
                 int contextJsonSize = NativeMethods.StringEncoding.GetByteCount(contextJson);
                 if (eventId == null)
@@ -591,6 +621,80 @@ namespace Rl.Net
                 fixed (byte* eventIdUtf8Bytes = NativeMethods.StringEncoding.GetBytes(eventId))
                 {
                     return NativeMethods.LiveModelRequestMultiSlotDecisionDetailedWithBaselineAndFlags(liveModel, (IntPtr)eventIdUtf8Bytes, (IntPtr)contextJsonUtf8Bytes, contextJsonSize, flags, multiSlotResponseDetailed, (IntPtr)baselineActionsFixed, (IntPtr)baselineActions.Length, apiStatus);
+                }
+            }
+        }
+
+        unsafe private static int LiveModelRequestEpisodicDecisionWithFlags(IntPtr liveModel, string eventId, string previousEventId, string contextJson, uint flags, IntPtr rankingResponse, IntPtr episodeState, IntPtr apiStatus)
+        {
+            CheckJsonString(contextJson);
+
+            fixed (byte* contextJsonUtf8Bytes = NativeMethods.StringEncoding.GetBytes(contextJson))
+            {
+                if (eventId == null)
+                {
+                    if (previousEventId != null)
+                    {
+                        throw new ArgumentException($"eventId is null but previousEventId is not null.");
+                    }
+                    else
+                    {
+                        return NativeMethods.LiveModelRequestEpisodicDecisionWithFlags(liveModel, IntPtr.Zero, IntPtr.Zero, (IntPtr)contextJsonUtf8Bytes, flags, rankingResponse, episodeState, apiStatus);
+                    }
+                }
+                else
+                {
+                    fixed (byte* eventIdUtf8Bytes = NativeMethods.StringEncoding.GetBytes(eventId))
+                    {
+                        if (previousEventId == null)
+                        {
+                            return NativeMethods.LiveModelRequestEpisodicDecisionWithFlags(liveModel, (IntPtr)eventIdUtf8Bytes, IntPtr.Zero, (IntPtr)contextJsonUtf8Bytes, flags, rankingResponse, episodeState, apiStatus);
+                        }
+                        else
+                        {
+                            fixed (byte* previousEventIdUtf8Bytes = NativeMethods.StringEncoding.GetBytes(eventId))
+                            {
+                                return NativeMethods.LiveModelRequestEpisodicDecisionWithFlags(liveModel, (IntPtr)eventIdUtf8Bytes, (IntPtr)previousEventIdUtf8Bytes, (IntPtr)contextJsonUtf8Bytes, flags, rankingResponse, episodeState, apiStatus);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        unsafe private static int LiveModelRequestEpisodicDecision(IntPtr liveModel, string eventId, string previousEventId, string contextJson, IntPtr rankingResponse, IntPtr episodeState, IntPtr apiStatus)
+        {
+            CheckJsonString(contextJson);
+
+            fixed (byte* contextJsonUtf8Bytes = NativeMethods.StringEncoding.GetBytes(contextJson))
+            {
+                if (eventId == null)
+                {
+                    if (previousEventId != null)
+                    {
+                        throw new ArgumentException($"eventId is null but previousEventId is not null.");
+                    }
+                    else
+                    {
+                        return NativeMethods.LiveModelRequestEpisodicDecision(liveModel, IntPtr.Zero, IntPtr.Zero, (IntPtr)contextJsonUtf8Bytes, rankingResponse, episodeState, apiStatus);
+                    }
+                }
+                else
+                {
+                    fixed (byte* eventIdUtf8Bytes = NativeMethods.StringEncoding.GetBytes(eventId))
+                    {
+                        if (previousEventId == null)
+                        {
+                            return NativeMethods.LiveModelRequestEpisodicDecision(liveModel, (IntPtr)eventIdUtf8Bytes, IntPtr.Zero, (IntPtr)contextJsonUtf8Bytes, rankingResponse, episodeState, apiStatus);
+                        }
+                        else
+                        {
+                            fixed (byte* previousEventIdUtf8Bytes = NativeMethods.StringEncoding.GetBytes(eventId))
+                            {
+                                return NativeMethods.LiveModelRequestEpisodicDecision(liveModel, (IntPtr)eventIdUtf8Bytes, (IntPtr)previousEventIdUtf8Bytes, (IntPtr)contextJsonUtf8Bytes, rankingResponse, episodeState, apiStatus);
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -754,10 +858,10 @@ namespace Rl.Net
         public void Init()
         {
             using (ApiStatus apiStatus = new ApiStatus())
-            if (!this.TryInit(apiStatus))
-            {
-                throw new RLException(apiStatus);
-            }
+                if (!this.TryInit(apiStatus))
+                {
+                    throw new RLException(apiStatus);
+                }
         }
 
         public bool TryChooseRank(string eventId, string contextJson, out RankingResponse response, ApiStatus apiStatus = null)
@@ -779,10 +883,10 @@ namespace Rl.Net
             RankingResponse result = new RankingResponse();
 
             using (ApiStatus apiStatus = new ApiStatus())
-            if (!this.TryChooseRank(eventId, contextJson, result, apiStatus))
-            {
-                throw new RLException(apiStatus);
-            }
+                if (!this.TryChooseRank(eventId, contextJson, result, apiStatus))
+                {
+                    throw new RLException(apiStatus);
+                }
 
             return result;
         }
@@ -806,10 +910,10 @@ namespace Rl.Net
             RankingResponse result = new RankingResponse();
 
             using (ApiStatus apiStatus = new ApiStatus())
-            if (!this.TryChooseRank(eventId, contextJson, flags, result, apiStatus))
-            {
-                throw new RLException(apiStatus);
-            }
+                if (!this.TryChooseRank(eventId, contextJson, flags, result, apiStatus))
+                {
+                    throw new RLException(apiStatus);
+                }
 
             return result;
         }
@@ -833,10 +937,10 @@ namespace Rl.Net
             ContinuousActionResponse result = new ContinuousActionResponse();
 
             using (ApiStatus apiStatus = new ApiStatus())
-            if (!this.TryRequestContinuousAction(eventId, contextJson, result, apiStatus))
-            {
-                throw new RLException(apiStatus);
-            }
+                if (!this.TryRequestContinuousAction(eventId, contextJson, result, apiStatus))
+                {
+                    throw new RLException(apiStatus);
+                }
 
             return result;
         }
@@ -860,10 +964,10 @@ namespace Rl.Net
             ContinuousActionResponse result = new ContinuousActionResponse();
 
             using (ApiStatus apiStatus = new ApiStatus())
-            if (!this.TryRequestContinuousAction(eventId, contextJson, flags, result, apiStatus))
-            {
-                throw new RLException(apiStatus);
-            }
+                if (!this.TryRequestContinuousAction(eventId, contextJson, flags, result, apiStatus))
+                {
+                    throw new RLException(apiStatus);
+                }
 
             return result;
         }
@@ -887,10 +991,10 @@ namespace Rl.Net
             DecisionResponse result = new DecisionResponse();
 
             using (ApiStatus apiStatus = new ApiStatus())
-            if (!this.TryRequestDecision(contextJson, result, apiStatus))
-            {
-                throw new RLException(apiStatus);
-            }
+                if (!this.TryRequestDecision(contextJson, result, apiStatus))
+                {
+                    throw new RLException(apiStatus);
+                }
 
             return result;
         }
@@ -914,10 +1018,10 @@ namespace Rl.Net
             DecisionResponse result = new DecisionResponse();
 
             using (ApiStatus apiStatus = new ApiStatus())
-            if (!this.TryRequestDecision(contextJson, flags, result, apiStatus))
-            {
-                throw new RLException(apiStatus);
-            }
+                if (!this.TryRequestDecision(contextJson, flags, result, apiStatus))
+                {
+                    throw new RLException(apiStatus);
+                }
 
             return result;
         }
@@ -941,10 +1045,10 @@ namespace Rl.Net
             MultiSlotResponse result = new MultiSlotResponse();
 
             using (ApiStatus apiStatus = new ApiStatus())
-            if (!this.TryRequestMultiSlotDecision(eventId, contextJson, result, apiStatus))
-            {
-                throw new RLException(apiStatus);
-            }
+                if (!this.TryRequestMultiSlotDecision(eventId, contextJson, result, apiStatus))
+                {
+                    throw new RLException(apiStatus);
+                }
 
             return result;
         }
@@ -968,10 +1072,10 @@ namespace Rl.Net
             MultiSlotResponse result = new MultiSlotResponse();
 
             using (ApiStatus apiStatus = new ApiStatus())
-            if (!this.TryRequestMultiSlotDecision(eventId, contextJson, flags, result, apiStatus))
-            {
-                throw new RLException(apiStatus);
-            }
+                if (!this.TryRequestMultiSlotDecision(eventId, contextJson, flags, result, apiStatus))
+                {
+                    throw new RLException(apiStatus);
+                }
 
             return result;
         }
@@ -1083,6 +1187,25 @@ namespace Rl.Net
             return result;
         }
 
+        public bool TryRequestEpisodicDecision(string eventId, string previousEventId, string contextJson, ActionFlags flags, EpisodeState episodes, RankingResponse resp, ApiStatus apiStatus)
+        {
+            int result = LiveModelRequestEpisodicDecisionWithFlags(this.DangerousGetHandle(), eventId, previousEventId, contextJson, (uint)flags, episodes.DangerousGetHandle(), resp.DangerousGetHandle(), apiStatus.DangerousGetHandle());
+            GC.KeepAlive(this);
+            return result == NativeMethods.SuccessStatus;
+        }
+
+        public RankingResponse RequestEpisodicDecision(string eventId, string previousEventId, string contextJson, ActionFlags flags, EpisodeState episodes)
+        {
+            RankingResponse resp = new RankingResponse();
+
+            using (ApiStatus apiStatus = new ApiStatus())
+                if (!this.TryRequestEpisodicDecision(eventId, previousEventId, contextJson, flags, episodes, resp, apiStatus))
+                {
+                    throw new RLException(apiStatus);
+                }
+            return resp;
+        }
+
         [Obsolete("Use TryQueueActionTakenEvent instead.")]
         public bool TryReportActionTaken(string eventId, ApiStatus apiStatus = null)
         => this.TryQueueActionTakenEvent(eventId, apiStatus);
@@ -1103,10 +1226,10 @@ namespace Rl.Net
         public void QueueActionTakenEvent(string eventId)
         {
             using (ApiStatus apiStatus = new ApiStatus())
-            if (!this.TryQueueActionTakenEvent(eventId, apiStatus))
-            {
-                throw new RLException(apiStatus);
-            }
+                if (!this.TryQueueActionTakenEvent(eventId, apiStatus))
+                {
+                    throw new RLException(apiStatus);
+                }
         }
 
         [Obsolete("Use TryQueueOutcomeEvent instead.")]
@@ -1129,10 +1252,10 @@ namespace Rl.Net
         public void QueueOutcomeEvent(string eventId, float outcome)
         {
             using (ApiStatus apiStatus = new ApiStatus())
-            if (!this.TryQueueOutcomeEvent(eventId, outcome, apiStatus))
-            {
-                throw new RLException(apiStatus);
-            }
+                if (!this.TryQueueOutcomeEvent(eventId, outcome, apiStatus))
+                {
+                    throw new RLException(apiStatus);
+                }
         }
 
         [Obsolete("Use TryQueueOutcomeEvent instead.")]
@@ -1155,10 +1278,10 @@ namespace Rl.Net
         public void QueueOutcomeEvent(string eventId, string outcomeJson)
         {
             using (ApiStatus apiStatus = new ApiStatus())
-            if (!this.TryQueueOutcomeEvent(eventId, outcomeJson, apiStatus))
-            {
-                throw new RLException(apiStatus);
-            }
+                if (!this.TryQueueOutcomeEvent(eventId, outcomeJson, apiStatus))
+                {
+                    throw new RLException(apiStatus);
+                }
         }
 
         public bool TryQueueOutcomeEvent(string eventId, uint slotIndex, float outcome, ApiStatus apiStatus = null)
@@ -1173,10 +1296,10 @@ namespace Rl.Net
         public void QueueOutcomeEvent(string eventId, uint slotIndex, float outcome)
         {
             using (ApiStatus apiStatus = new ApiStatus())
-            if (!this.TryQueueOutcomeEvent(eventId, slotIndex, outcome, apiStatus))
-            {
-                throw new RLException(apiStatus);
-            }
+                if (!this.TryQueueOutcomeEvent(eventId, slotIndex, outcome, apiStatus))
+                {
+                    throw new RLException(apiStatus);
+                }
         }
 
         public bool TryQueueOutcomeEvent(string eventId, uint slotIndex, string outcomeJson, ApiStatus apiStatus = null)
@@ -1191,10 +1314,10 @@ namespace Rl.Net
         public void QueueOutcomeEvent(string eventId, uint slotIndex, string outcomeJson)
         {
             using (ApiStatus apiStatus = new ApiStatus())
-            if (!this.TryQueueOutcomeEvent(eventId, slotIndex, outcomeJson, apiStatus))
-            {
-                throw new RLException(apiStatus);
-            }
+                if (!this.TryQueueOutcomeEvent(eventId, slotIndex, outcomeJson, apiStatus))
+                {
+                    throw new RLException(apiStatus);
+                }
         }
 
         public bool TryQueueOutcomeEvent(string eventId, string slotId, float outcome, ApiStatus apiStatus = null)
@@ -1209,10 +1332,10 @@ namespace Rl.Net
         public void QueueOutcomeEvent(string eventId, string slotId, float outcome)
         {
             using (ApiStatus apiStatus = new ApiStatus())
-            if (!this.TryQueueOutcomeEvent(eventId, slotId, outcome, apiStatus))
-            {
-                throw new RLException(apiStatus);
-            }
+                if (!this.TryQueueOutcomeEvent(eventId, slotId, outcome, apiStatus))
+                {
+                    throw new RLException(apiStatus);
+                }
         }
 
         public bool TryQueueOutcomeEvent(string eventId, string slotId, string outcomeJson, ApiStatus apiStatus = null)
@@ -1227,19 +1350,19 @@ namespace Rl.Net
         public void QueueOutcomeEvent(string eventId, string slotId, string outcomeJson)
         {
             using (ApiStatus apiStatus = new ApiStatus())
-            if (!this.TryQueueOutcomeEvent(eventId, slotId, outcomeJson, apiStatus))
-            {
-                throw new RLException(apiStatus);
-            }
+                if (!this.TryQueueOutcomeEvent(eventId, slotId, outcomeJson, apiStatus))
+                {
+                    throw new RLException(apiStatus);
+                }
         }
 
         public void RefreshModel()
         {
             using (ApiStatus apiStatus = new ApiStatus())
-            if (!this.TryRefreshModel(apiStatus))
-            {
-                throw new RLException(apiStatus);
-            }
+                if (!this.TryRefreshModel(apiStatus))
+                {
+                    throw new RLException(apiStatus);
+                }
         }
 
         public bool TryRefreshModel(ApiStatus apiStatus = null)

--- a/bindings/cs/rl.net/LiveModel.cs
+++ b/bindings/cs/rl.net/LiveModel.cs
@@ -1125,7 +1125,7 @@ namespace Rl.Net
 
         public bool TryRequestEpisodicDecision(string eventId, string previousEventId, string contextJson, ActionFlags flags, EpisodeState states, RankingResponse resp, ApiStatus apiStatus)
         {
-            int result = LiveModelRequestEpisodicDecisionWithFlags(this.DangerousGetHandle(), eventId, previousEventId, contextJson, (uint)flags, states.DangerousGetHandle(), resp.DangerousGetHandle(), apiStatus.DangerousGetHandle());
+            int result = LiveModelRequestEpisodicDecisionWithFlags(this.DangerousGetHandle(), eventId, previousEventId, contextJson, (uint)flags, resp.DangerousGetHandle(), states.DangerousGetHandle(), apiStatus.DangerousGetHandle());
             GC.KeepAlive(this);
             return result == NativeMethods.SuccessStatus;
         }

--- a/include/multistep.h
+++ b/include/multistep.h
@@ -26,7 +26,7 @@ public:
   episode_history(episode_history&& other) = default;
   episode_history& operator=(episode_history&& other) = default;
 
-  void update(const char* event_id, const char* previous_event_id, string_view context, const ranking_response& resp);
+  void update(const char* event_id, const char* previous_event_id, string_view context);
   std::string get_context(const char* previous_event_id, string_view context) const;
 
   size_t size() const;
@@ -53,7 +53,7 @@ public:
   const episode_history& get_history() const;
   size_t size() const;
 
-  int update(const char* event_id, const char* previous_event_id, string_view context, const ranking_response& response,
+  int update(const char* event_id, const char* previous_event_id, string_view context,
       api_status* error = nullptr);
 
 private:

--- a/rlclientlib/live_model_impl.cc
+++ b/rlclientlib/live_model_impl.cc
@@ -730,7 +730,7 @@ int live_model_impl::request_episodic_decision(const char* event_id, const char*
 
   resp.set_event_id(event_id);
 
-  RETURN_IF_FAIL(episode.update(event_id, previous_id, context_json, resp, status));
+  RETURN_IF_FAIL(episode.update(event_id, previous_id, context_json, status));
 
   if (episode.size() == 1)
   {

--- a/rlclientlib/multistep.cc
+++ b/rlclientlib/multistep.cc
@@ -5,7 +5,7 @@
 namespace reinforcement_learning
 {
 void episode_history::update(
-    const char* event_id, const char* previous_event_id, string_view context, const ranking_response& resp)
+    const char* event_id, const char* previous_event_id, string_view context)
 {
   _depths[event_id] = this->get_depth(previous_event_id) + 1;
 }
@@ -33,10 +33,10 @@ const episode_history& episode_state::get_history() const { return _history; }
 
 size_t episode_state::size() const { return _history.size(); }
 
-int episode_state::update(const char* event_id, const char* previous_event_id, string_view context,
-    const ranking_response& response, api_status* status)
+int episode_state::update(const char* event_id, const char* previous_event_id, string_view context, 
+    api_status* status)
 {
-  _history.update(event_id, previous_event_id, context, response);
+  _history.update(event_id, previous_event_id, context);
   return error_code::success;
 }
 }  // namespace reinforcement_learning

--- a/unit_test/multistep_test.cc
+++ b/unit_test/multistep_test.cc
@@ -13,12 +13,11 @@ using namespace reinforcement_learning;
 BOOST_AUTO_TEST_CASE(multistep_depth_is_added)
 {
   episode_history history;
-  ranking_response resp;
   const std::string context = R"({"f":1})";
 
   const std::string first = history.get_context(nullptr, context.c_str());
   BOOST_CHECK_EQUAL(R"({"episode":{"depth":"1"},"f":1})", first.c_str());
-  history.update("0", nullptr, context.c_str(), resp);
+  history.update("0", nullptr, context.c_str());
 
   const std::string second = history.get_context("0", context.c_str());
   BOOST_CHECK_EQUAL(R"({"episode":{"depth":"2"},"f":1})", second.c_str());


### PR DESCRIPTION
This PR adds the C# binding for the Episodic RL interface.  The usage example is implemented in the test as well:

```
        [TestMethod]
        public void Test_LiveModel_RequestEpisodicE2E()
        {
            LiveModel liveModel = this.ConfigureLiveModel(PseudoLocConfigJsonVwModel);
            EpisodeState state = new EpisodeState("episode-0");

            state.Update("event1", "event0", ContextJson);

            var response = liveModel.RequestEpisodicDecision("event1", null, ContextJson, ActionFlags.Default, state);
            Assert.AreEqual(0, response.ChosenAction);
        }
```