### PR TITLE
remove explore only from rank call, and send first rank call to vw model

### DIFF
--- a/rlclientlib/live_model_impl.cc
+++ b/rlclientlib/live_model_impl.cc
@@ -93,7 +93,8 @@ int live_model_impl::choose_rank(
 
   _model->choose_rank(event_id, seed, context, action_ids, action_pdf, model_version, status);
 
-  RETURN_IF_FAIL(sample_and_populate_response(seed, action_ids, action_pdf, std::move(model_version), response, _trace_logger.get(), status));
+  RETURN_IF_FAIL(sample_and_populate_response(
+      seed, action_ids, action_pdf, std::move(model_version), response, _trace_logger.get(), status));
 
   response.set_event_id(event_id);
 

--- a/rlclientlib/live_model_impl.h
+++ b/rlclientlib/live_model_impl.h
@@ -84,8 +84,6 @@ private:
   int init_trace(api_status* status);
   static void _handle_model_update(const model_management::model_data& data, live_model_impl* ctxt);
   void handle_model_update(const model_management::model_data& data);
-  int explore_only(const char* event_id, string_view context, ranking_response& response, api_status* status) const;
-  int explore_exploit(const char* event_id, string_view context, ranking_response& response, api_status* status) const;
   template <typename D>
   int report_outcome_internal(const char* event_id, D outcome, api_status* status);
   template <typename D, typename I>

--- a/unit_test/live_model_test.cc
+++ b/unit_test/live_model_test.cc
@@ -426,6 +426,87 @@ BOOST_AUTO_TEST_CASE(live_model_request_decision)
   BOOST_CHECK_EQUAL(resp1.get_action_id(), 1);
 }
 
+BOOST_AUTO_TEST_CASE(live_model_ranking_request_check_response_pdf_explore_only)
+{
+  // create a simple ds configuration
+  u::configuration config;
+  cfg::create_from_json(JSON_CFG, config);
+  config.set(r::name::EH_TEST, "true");
+  config.set(
+      r::name::MODEL_VW_INITIAL_COMMAND_LINE, "--cb_explore_adf --json --quiet --epsilon 0.3 --first_only --id N/A");
+
+  r::api_status status;
+
+  // create the ds live_model, and initialize it with the config
+  r::live_model model(config);
+
+  BOOST_CHECK_EQUAL(model.init(&status), err::success);
+  const auto event_id = "event_id";
+
+  r::ranking_response response;
+
+  const auto JSON_CB_CONTEXT_3ACTIONS =
+    R"({"GUser":{"id":"a","major":"eng","hobby":"hiking"},"_multi":[{"TAction":{"a1":"f1"} },{"TAction":{"a2":"f2"}},{"TAction":{"a3":"f3"}}]})";
+
+  // request ranking
+  BOOST_CHECK_EQUAL(model.choose_rank(event_id, JSON_CB_CONTEXT_3ACTIONS, response), err::success);
+
+  size_t num_actions = response.size();
+  BOOST_CHECK_EQUAL(num_actions, 3);
+
+  const float EXPECTED_PROBS[3] = {0.8f, 0.1f, 0.1f};
+
+  // check that our PDF is what we expected
+  r::ranking_response::iterator it = response.begin();
+
+  for (uint32_t i = 0; i < num_actions; i++)
+  {
+    auto action_probability = *(it + i);
+    BOOST_CHECK_CLOSE(action_probability.probability, EXPECTED_PROBS[action_probability.action_id], FLOAT_TOL);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(live_model_ranking_w_las_request_check_response_pdf_explore_only)
+{
+  // create a simple ds configuration
+  u::configuration config;
+  cfg::create_from_json(JSON_CFG, config);
+  config.set(r::name::EH_TEST, "true");
+  config.set(r::name::MODEL_SRC, r::value::NO_MODEL_DATA);
+  config.set(
+      r::name::MODEL_VW_INITIAL_COMMAND_LINE, "--cb_explore_adf --json --quiet --epsilon 0.3 --first_only --id N/A --large_action_space --max_actions 2");
+
+  r::api_status status;
+
+  // create the ds live_model, and initialize it with the config
+  r::live_model model(config);
+
+  BOOST_CHECK_EQUAL(model.init(&status), err::success);
+  const auto event_id = "event_id";
+
+  r::ranking_response response;
+
+  const auto JSON_CB_CONTEXT_3ACTIONS =
+    R"({"GUser":{"id":"a","major":"eng","hobby":"hiking"},"_multi":[{"TAction":{"a1":"f1"} },{"TAction":{"a2":"f2"}},{"TAction":{"a3":"f3"}}]})";
+
+  // request ranking
+  BOOST_CHECK_EQUAL(model.choose_rank(event_id, JSON_CB_CONTEXT_3ACTIONS, response), err::success);
+
+  size_t num_actions = response.size();
+  BOOST_CHECK_EQUAL(num_actions, 3);
+
+  const float EXPECTED_PROBS[3] = {0.85f, 0.0f, 0.15f};
+
+  // check that our PDF is what we expected
+  r::ranking_response::iterator it = response.begin();
+
+  for (uint32_t i = 0; i < num_actions; i++)
+  {
+    auto action_probability = *(it + i);
+    BOOST_CHECK_CLOSE(action_probability.probability, EXPECTED_PROBS[action_probability.action_id], FLOAT_TOL);
+  }
+}
+
 BOOST_AUTO_TEST_CASE(live_model_ranking_request_pdf_passthrough)
 {
   // create a simple ds configuration

--- a/unit_test/live_model_test.cc
+++ b/unit_test/live_model_test.cc
@@ -432,6 +432,9 @@ BOOST_AUTO_TEST_CASE(live_model_ranking_request_check_response_pdf_explore_only)
   u::configuration config;
   cfg::create_from_json(JSON_CFG, config);
   config.set(r::name::EH_TEST, "true");
+  config.set(r::name::MODEL_SRC, r::value::NO_MODEL_DATA);
+  config.set(r::name::OBSERVATION_SENDER_IMPLEMENTATION, r::value::OBSERVATION_FILE_SENDER);
+  config.set(r::name::INTERACTION_SENDER_IMPLEMENTATION, r::value::INTERACTION_FILE_SENDER);
   config.set(
       r::name::MODEL_VW_INITIAL_COMMAND_LINE, "--cb_explore_adf --json --quiet --epsilon 0.3 --first_only --id N/A");
 
@@ -473,6 +476,8 @@ BOOST_AUTO_TEST_CASE(live_model_ranking_w_las_request_check_response_pdf_explore
   cfg::create_from_json(JSON_CFG, config);
   config.set(r::name::EH_TEST, "true");
   config.set(r::name::MODEL_SRC, r::value::NO_MODEL_DATA);
+  config.set(r::name::OBSERVATION_SENDER_IMPLEMENTATION, r::value::OBSERVATION_FILE_SENDER);
+  config.set(r::name::INTERACTION_SENDER_IMPLEMENTATION, r::value::INTERACTION_FILE_SENDER);
   config.set(r::name::MODEL_VW_INITIAL_COMMAND_LINE,
       "--cb_explore_adf --json --quiet --epsilon 0.3 --first_only --id N/A --large_action_space --max_actions 2");
 

--- a/unit_test/live_model_test.cc
+++ b/unit_test/live_model_test.cc
@@ -446,7 +446,7 @@ BOOST_AUTO_TEST_CASE(live_model_ranking_request_check_response_pdf_explore_only)
   r::ranking_response response;
 
   const auto JSON_CB_CONTEXT_3ACTIONS =
-    R"({"GUser":{"id":"a","major":"eng","hobby":"hiking"},"_multi":[{"TAction":{"a1":"f1"} },{"TAction":{"a2":"f2"}},{"TAction":{"a3":"f3"}}]})";
+      R"({"GUser":{"id":"a","major":"eng","hobby":"hiking"},"_multi":[{"TAction":{"a1":"f1"} },{"TAction":{"a2":"f2"}},{"TAction":{"a3":"f3"}}]})";
 
   // request ranking
   BOOST_CHECK_EQUAL(model.choose_rank(event_id, JSON_CB_CONTEXT_3ACTIONS, response), err::success);
@@ -473,8 +473,8 @@ BOOST_AUTO_TEST_CASE(live_model_ranking_w_las_request_check_response_pdf_explore
   cfg::create_from_json(JSON_CFG, config);
   config.set(r::name::EH_TEST, "true");
   config.set(r::name::MODEL_SRC, r::value::NO_MODEL_DATA);
-  config.set(
-      r::name::MODEL_VW_INITIAL_COMMAND_LINE, "--cb_explore_adf --json --quiet --epsilon 0.3 --first_only --id N/A --large_action_space --max_actions 2");
+  config.set(r::name::MODEL_VW_INITIAL_COMMAND_LINE,
+      "--cb_explore_adf --json --quiet --epsilon 0.3 --first_only --id N/A --large_action_space --max_actions 2");
 
   r::api_status status;
 
@@ -487,7 +487,7 @@ BOOST_AUTO_TEST_CASE(live_model_ranking_w_las_request_check_response_pdf_explore
   r::ranking_response response;
 
   const auto JSON_CB_CONTEXT_3ACTIONS =
-    R"({"GUser":{"id":"a","major":"eng","hobby":"hiking"},"_multi":[{"TAction":{"a1":"f1"} },{"TAction":{"a2":"f2"}},{"TAction":{"a3":"f3"}}]})";
+      R"({"GUser":{"id":"a","major":"eng","hobby":"hiking"},"_multi":[{"TAction":{"a1":"f1"} },{"TAction":{"a2":"f2"}},{"TAction":{"a3":"f3"}}]})";
 
   // request ranking
   BOOST_CHECK_EQUAL(model.choose_rank(event_id, JSON_CB_CONTEXT_3ACTIONS, response), err::success);

--- a/unit_test/mock_util.cc
+++ b/unit_test/mock_util.cc
@@ -69,10 +69,17 @@ std::unique_ptr<fakeit::Mock<m::i_model>> get_mock_model(m::model_type_t model_t
 {
   auto mock = std::unique_ptr<Mock<m::i_model>>(new fakeit::Mock<m::i_model>());
 
-  const auto choose_rank_fn = [](const char*, uint64_t, r::string_view, std::vector<int>&, std::vector<float>&,
+  const auto choose_rank_fn = [](const char*, uint64_t, r::string_view, std::vector<int>& actions, std::vector<float>& scores,
                                   std::string& model_version, r::api_status*)
   {
     model_version = "model_id";
+    actions.resize(2);
+    scores.resize(2);
+    for (size_t i = 0; i < 2; ++i)
+    {
+      actions[i] = i;
+      scores[i] = 0.5f;
+    }
     return r::error_code::success;
   };
 

--- a/unit_test/mock_util.cc
+++ b/unit_test/mock_util.cc
@@ -69,8 +69,8 @@ std::unique_ptr<fakeit::Mock<m::i_model>> get_mock_model(m::model_type_t model_t
 {
   auto mock = std::unique_ptr<Mock<m::i_model>>(new fakeit::Mock<m::i_model>());
 
-  const auto choose_rank_fn = [](const char*, uint64_t, r::string_view, std::vector<int>& actions, std::vector<float>& scores,
-                                  std::string& model_version, r::api_status*)
+  const auto choose_rank_fn = [](const char*, uint64_t, r::string_view, std::vector<int>& actions,
+                                  std::vector<float>& scores, std::string& model_version, r::api_status*)
   {
     model_version = "model_id";
     actions.resize(2);


### PR DESCRIPTION
added unit test for rank call and for rank call with LAS

rank for mock function made to return a basic pdf since explore only is not accessed anymore