### PR TITLE
[feat] multistep_loop APIs

### DIFF
--- a/examples/basic_usage_cpp/basic_usage_cpp.cc
+++ b/examples/basic_usage_cpp/basic_usage_cpp.cc
@@ -283,7 +283,7 @@ int basic_usage_multistep()
 
   r::api_status status;
 
-  r::live_model rl(config);
+  r::multistep_loop rl(config);
 
   if (rl.init(&status) != err::success)
   {

--- a/examples/basic_usage_cpp/basic_usage_cpp.h
+++ b/examples/basic_usage_cpp/basic_usage_cpp.h
@@ -11,7 +11,7 @@
 #include "cb_loop.h"
 #include "ccb_loop.h"
 #include "config_utility.h"
-#include "live_model.h"
+#include "multistep_loop.h"
 #include "slates_loop.h"
 
 #include <fstream>

--- a/examples/test_cpp/test_loop.cc
+++ b/examples/test_cpp/test_loop.cc
@@ -64,7 +64,7 @@ bool test_loop::init()
     return false;
   }
 
-  rl_episodic = std::unique_ptr<r::live_model>(new r::live_model(config, _on_error, nullptr));
+  rl_episodic = std::unique_ptr<r::multistep_loop>(new r::multistep_loop(config, _on_error, nullptr));
   if (rl_episodic->init(&status) != err::success)
   {
     std::cout << status.get_error_msg() << std::endl;

--- a/examples/test_cpp/test_loop.h
+++ b/examples/test_cpp/test_loop.h
@@ -4,6 +4,7 @@
 #include "ccb_loop.h"
 #include "experiment_controller.h"
 #include "live_model.h"
+#include "multistep_loop.h"
 #include "test_data_provider.h"
 
 #include <boost/program_options.hpp>
@@ -47,5 +48,5 @@ private:
   std::vector<std::shared_ptr<std::ofstream>> loggers;
   std::unique_ptr<reinforcement_learning::cb_loop> rl_cb;
   std::unique_ptr<reinforcement_learning::ccb_loop> rl_ccb;
-  std::unique_ptr<reinforcement_learning::live_model> rl_episodic;
+  std::unique_ptr<reinforcement_learning::multistep_loop> rl_episodic;
 };

--- a/include/loop_apis/base_loop.h
+++ b/include/loop_apis/base_loop.h
@@ -44,10 +44,10 @@ class configuration;  //
 
 struct str_view
 {
-  str_view(const char* str, int size) : str(str), size(size) {}
+  str_view(const char* str, size_t size) : str(str), size(size) {}
   str_view(const char* str) : str(str), size(str == nullptr ? 0 : strlen(str)) {}
   const char* str;
-  int size;
+  size_t size;
 };
 
 // Reinforcement learning client

--- a/include/loop_apis/multistep_loop.h
+++ b/include/loop_apis/multistep_loop.h
@@ -40,8 +40,8 @@ public:
    * @param status  Optional field with detailed string description if there is an error
    * @return int Return error code.  This will also be returned in the api_status object
    */
-  int request_episodic_decision(str_view event_id, str_view previous_id, str_view context_json,
-      ranking_response& resp, episode_state& episode, api_status* status = nullptr);
+  int request_episodic_decision(str_view event_id, str_view previous_id, str_view context_json, ranking_response& resp,
+      episode_state& episode, api_status* status = nullptr);
 
   /**
    * @brief Choose an action, given a list of actions, action features and context features. The
@@ -59,8 +59,8 @@ public:
    * @param status  Optional field with detailed string description if there is an error
    * @return int Return error code.  This will also be returned in the api_status object
    */
-  int request_episodic_decision(str_view event_id, str_view previous_id, str_view context_json,
-      unsigned int flags, ranking_response& resp, episode_state& episode, api_status* status = nullptr);
+  int request_episodic_decision(str_view event_id, str_view previous_id, str_view context_json, unsigned int flags,
+      ranking_response& resp, episode_state& episode, api_status* status = nullptr);
 
   /**
    * @brief Report outcome of a decision based on a pair of episode and event identifiers.

--- a/include/loop_apis/multistep_loop.h
+++ b/include/loop_apis/multistep_loop.h
@@ -1,0 +1,135 @@
+/**
+ * @brief RL Inference API definition.
+ *
+ * @file cb_loop.h
+ * @author Peter Chang et al
+ * @date 2023-05-02
+ */
+#pragma once
+#include "action_flags.h"
+#include "base_loop.h"
+#include "err_constants.h"
+#include "factory_resolver.h"
+#include "future_compat.h"
+#include "multistep.h"
+#include "ranking_response.h"
+#include "sender.h"
+
+#include <functional>
+#include <memory>
+
+namespace reinforcement_learning
+{
+class multistep_loop : public base_loop
+{
+public:
+  using base_loop::base_loop;
+
+  /**
+   * @brief Choose an action, given a list of actions, action features and context features. The
+   * inference library chooses an action by creating a probability distribution over the actions
+   * and then sampling from it.
+   * @param event_id  The unique identifier for this interaction. The same event_id should be used when
+   *                  reporting the outcome for this action.
+   * @param previous_id The unique identifier for the previous interaction in the current episode.
+   * @param context_json Contains action, action features and context features in json format
+   * @param resp Ranking response contains the chosen action, probability distribution used for sampling actions and
+   * ranked actions
+   * @param episode_state Object containing the state information for the current episode. The same object must
+   *                      be passed in for every interaction within a single episode
+   * @param status  Optional field with detailed string description if there is an error
+   * @return int Return error code.  This will also be returned in the api_status object
+   */
+  int request_episodic_decision(str_view event_id, str_view previous_id, str_view context_json,
+      ranking_response& resp, episode_state& episode, api_status* status = nullptr);
+
+  /**
+   * @brief Choose an action, given a list of actions, action features and context features. The
+   * inference library chooses an action by creating a probability distribution over the actions
+   * and then sampling from it.
+   * @param event_id  The unique identifier for this interaction. The same event_id should be used when
+   *                  reporting the outcome for this action.
+   * @param previous_id The unique identifier for the previous interaction in the current episode.
+   * @param context_json Contains action, action features and context features in json format
+   * @param flags Action flags (see action_flags.h)
+   * @param resp Ranking response contains the chosen action, probability distribution used for sampling actions and
+   * ranked actions
+   * @param episode_state Object containing the state information for the current episode. The same object must
+   *                      be passed in for every interaction within a single episode
+   * @param status  Optional field with detailed string description if there is an error
+   * @return int Return error code.  This will also be returned in the api_status object
+   */
+  int request_episodic_decision(str_view event_id, str_view previous_id, str_view context_json,
+      unsigned int flags, ranking_response& resp, episode_state& episode, api_status* status = nullptr);
+
+  /**
+   * @brief Report outcome of a decision based on a pair of episode and event identifiers.
+   *        The outcome is associated with an individual interaction
+   *
+   * @param episode_id  The unique episode_id used when choosing an action should be presented here.
+   * @param event_id Index of the partial outcome; an individual interaction within an episode.
+   * @param outcome Outcome as float.
+   * @param status  Optional field with detailed string description if there is an error
+   * @return int Return error code.  This will also be returned in the api_status object
+   */
+  int report_outcome(str_view episode_id, str_view event_id, float outcome, api_status* status = nullptr);
+
+  /**
+   * @brief Report outcome of a decision based on a pair of episode and event identifiers.
+   *        The outcome is associated with an individual interaction
+   *
+   * @param episode_id  The unique episode_id used when choosing an action should be presented here.
+   * @param event_id Index of the partial outcome; an individual interaction within an episode.
+   * @param outcome Outcome as string.
+   * @param status  Optional field with detailed string description if there is an error
+   * @return int Return error code.  This will also be returned in the api_status object
+   */
+  int report_outcome(str_view episode_id, str_view event_id, str_view outcome, api_status* status = nullptr);
+
+  /**
+   * @brief Report outcome of a decision based on a pair of episode and event identifiers.
+   *        The outcome is associated with an individual interaction
+   *
+   * @param event_id Index of the partial outcome; an individual interaction within an episode.
+   * @param episode_state Object containing the state information for the current episode. This object is the same
+   *                      object that is passed in for the associated interaction
+   * @param outcome Outcome as float.
+   * @param status  Optional field with detailed string description if there is an error
+   * @return int Return error code.  This will also be returned in the api_status object
+   */
+  int report_outcome(str_view event_id, episode_state& episode, float outcome, api_status* status = nullptr);
+
+  /**
+   * @brief Report outcome of a decision based on a pair of episode and event identifiers.
+   *        The outcome is associated with an individual interaction
+   *
+   * @param event_id Index of the partial outcome; an individual interaction within an episode.
+   * @param episode_state Object containing the state information for the current episode. This object is the same
+   *                      object that is passed in for the associated interaction
+   * @param outcome Outcome as string.
+   * @param status  Optional field with detailed string description if there is an error
+   * @return int Return error code.  This will also be returned in the api_status object
+   */
+  int report_outcome(str_view event_id, episode_state& episode, str_view outcome, api_status* status = nullptr);
+
+  /**
+   * @brief Report outcome of a decision based on the episode_id. This outcome is associated with the entire episode.
+   *
+   * @param episode_id  The unique episode_id used when choosing an action should be presented here.
+   * @param outcome Outcome as float.
+   * @param status  Optional field with detailed string description if there is an error
+   * @return int Return error code.  This will also be returned in the api_status object
+   */
+  int report_outcome(str_view episode_id, float outcome, api_status* status = nullptr);
+
+  /**
+   * @brief Report outcome of a decision based on the episode_id. This outcome is associated with the entire episode.
+   *
+   * @param episode_id  The unique episode_id used when choosing an action should be presented here.
+   * @param outcome Outcome as string.
+   * @param status  Optional field with detailed string description if there is an error
+   * @return int Return error code.  This will also be returned in the api_status object
+   */
+  int report_outcome(str_view episode_id, str_view outcome, api_status* status = nullptr);
+};
+}  // namespace reinforcement_learning

--- a/rlclientlib/CMakeLists.txt
+++ b/rlclientlib/CMakeLists.txt
@@ -78,6 +78,7 @@ set(PROJECT_SOURCES
   model_mgmt/model_downloader.cc
   model_mgmt/model_mgmt.cc
   multistep.cc
+  multistep_loop.cc
   multi_slot_response.cc
   multi_slot_response_detailed.cc
   ranking_event.cc
@@ -120,6 +121,7 @@ set(PROJECT_PUBLIC_HEADERS
   ../include/loop_apis/ca_loop.h
   ../include/loop_apis/cb_loop.h
   ../include/loop_apis/ccb_loop.h
+  ../include/loop_apis/multistep_loop.h
   ../include/config_utility.h
   ../include/configuration.h
   ../include/constants.h

--- a/rlclientlib/multistep_loop.cc
+++ b/rlclientlib/multistep_loop.cc
@@ -5,53 +5,54 @@
 namespace reinforcement_learning
 {
 int multistep_loop::request_episodic_decision(str_view event_id, str_view previous_id, str_view context_json,
-      ranking_response& resp, episode_state& episode, api_status* status)
+    ranking_response& resp, episode_state& episode, api_status* status)
 {
-    INIT_CHECK();
-    return request_episodic_decision(event_id, previous_id, context_json, action_flags::DEFAULT, resp, episode, status);
+  INIT_CHECK();
+  return request_episodic_decision(event_id, previous_id, context_json, action_flags::DEFAULT, resp, episode, status);
 }
 
 int multistep_loop::request_episodic_decision(str_view event_id, str_view previous_id, str_view context_json,
-      unsigned int flags, ranking_response& resp, episode_state& episode, api_status* status)
+    unsigned int flags, ranking_response& resp, episode_state& episode, api_status* status)
 {
-    INIT_CHECK();
-    return _pimpl->request_episodic_decision(event_id.str, previous_id.str, {context_json.str, context_json.size}, flags, resp, episode, status);
+  INIT_CHECK();
+  return _pimpl->request_episodic_decision(event_id.str, previous_id.str,
+      {context_json.str, static_cast<size_t>(context_json.size)}, flags, resp, episode, status);
 }
 
 int multistep_loop::report_outcome(str_view episode_id, str_view event_id, float outcome, api_status* status)
 {
-    INIT_CHECK();
-    return _pimpl->report_outcome(episode_id.str, event_id.str, outcome, status);
+  INIT_CHECK();
+  return _pimpl->report_outcome(episode_id.str, event_id.str, outcome, status);
 }
 
 int multistep_loop::report_outcome(str_view episode_id, str_view event_id, str_view outcome, api_status* status)
 {
-    INIT_CHECK();
-    return _pimpl->report_outcome(episode_id.str, event_id.str, outcome.str, status);
+  INIT_CHECK();
+  return _pimpl->report_outcome(episode_id.str, event_id.str, outcome.str, status);
 }
 
 int multistep_loop::report_outcome(str_view event_id, episode_state& episode, float outcome, api_status* status)
 {
-    INIT_CHECK();
-    return _pimpl->report_outcome(event_id.str, episode.get_episode_id(), outcome, status);
+  INIT_CHECK();
+  return _pimpl->report_outcome(event_id.str, episode.get_episode_id(), outcome, status);
 }
 
 int multistep_loop::report_outcome(str_view event_id, episode_state& episode, str_view outcome, api_status* status)
 {
-    INIT_CHECK();
-    return _pimpl->report_outcome(event_id.str, episode.get_episode_id(), outcome.str, status);
+  INIT_CHECK();
+  return _pimpl->report_outcome(event_id.str, episode.get_episode_id(), outcome.str, status);
 }
 
 int multistep_loop::report_outcome(str_view episode_id, float outcome, api_status* status)
 {
-    INIT_CHECK();
-    return _pimpl->report_outcome(episode_id.str, outcome, status);
+  INIT_CHECK();
+  return _pimpl->report_outcome(episode_id.str, outcome, status);
 }
 
 int multistep_loop::report_outcome(str_view episode_id, str_view outcome, api_status* status)
 {
-    INIT_CHECK();
-    return _pimpl->report_outcome(episode_id.str, outcome.str, status);
+  INIT_CHECK();
+  return _pimpl->report_outcome(episode_id.str, outcome.str, status);
 }
 
-}
+}  // namespace reinforcement_learning

--- a/rlclientlib/multistep_loop.cc
+++ b/rlclientlib/multistep_loop.cc
@@ -16,7 +16,7 @@ int multistep_loop::request_episodic_decision(str_view event_id, str_view previo
 {
   INIT_CHECK();
   return _pimpl->request_episodic_decision(event_id.str, previous_id.str,
-      {context_json.str, static_cast<size_t>(context_json.size)}, flags, resp, episode, status);
+      {context_json.str, context_json.size}, flags, resp, episode, status);
 }
 
 int multistep_loop::report_outcome(str_view episode_id, str_view event_id, float outcome, api_status* status)

--- a/rlclientlib/multistep_loop.cc
+++ b/rlclientlib/multistep_loop.cc
@@ -15,8 +15,8 @@ int multistep_loop::request_episodic_decision(str_view event_id, str_view previo
     unsigned int flags, ranking_response& resp, episode_state& episode, api_status* status)
 {
   INIT_CHECK();
-  return _pimpl->request_episodic_decision(event_id.str, previous_id.str,
-      {context_json.str, context_json.size}, flags, resp, episode, status);
+  return _pimpl->request_episodic_decision(
+      event_id.str, previous_id.str, {context_json.str, context_json.size}, flags, resp, episode, status);
 }
 
 int multistep_loop::report_outcome(str_view episode_id, str_view event_id, float outcome, api_status* status)

--- a/rlclientlib/multistep_loop.cc
+++ b/rlclientlib/multistep_loop.cc
@@ -1,0 +1,57 @@
+#include "multistep_loop.h"
+
+#include "live_model_impl.h"
+
+namespace reinforcement_learning
+{
+int multistep_loop::request_episodic_decision(str_view event_id, str_view previous_id, str_view context_json,
+      ranking_response& resp, episode_state& episode, api_status* status)
+{
+    INIT_CHECK();
+    return request_episodic_decision(event_id, previous_id, context_json, action_flags::DEFAULT, resp, episode, status);
+}
+
+int multistep_loop::request_episodic_decision(str_view event_id, str_view previous_id, str_view context_json,
+      unsigned int flags, ranking_response& resp, episode_state& episode, api_status* status)
+{
+    INIT_CHECK();
+    return _pimpl->request_episodic_decision(event_id.str, previous_id.str, {context_json.str, context_json.size}, flags, resp, episode, status);
+}
+
+int multistep_loop::report_outcome(str_view episode_id, str_view event_id, float outcome, api_status* status)
+{
+    INIT_CHECK();
+    return _pimpl->report_outcome(episode_id.str, event_id.str, outcome, status);
+}
+
+int multistep_loop::report_outcome(str_view episode_id, str_view event_id, str_view outcome, api_status* status)
+{
+    INIT_CHECK();
+    return _pimpl->report_outcome(episode_id.str, event_id.str, outcome.str, status);
+}
+
+int multistep_loop::report_outcome(str_view event_id, episode_state& episode, float outcome, api_status* status)
+{
+    INIT_CHECK();
+    return _pimpl->report_outcome(event_id.str, episode.get_episode_id(), outcome, status);
+}
+
+int multistep_loop::report_outcome(str_view event_id, episode_state& episode, str_view outcome, api_status* status)
+{
+    INIT_CHECK();
+    return _pimpl->report_outcome(event_id.str, episode.get_episode_id(), outcome.str, status);
+}
+
+int multistep_loop::report_outcome(str_view episode_id, float outcome, api_status* status)
+{
+    INIT_CHECK();
+    return _pimpl->report_outcome(episode_id.str, outcome, status);
+}
+
+int multistep_loop::report_outcome(str_view episode_id, str_view outcome, api_status* status)
+{
+    INIT_CHECK();
+    return _pimpl->report_outcome(episode_id.str, outcome.str, status);
+}
+
+}


### PR DESCRIPTION
Added 2 new APIs for `report_outcome` that take in the event ID and the episode object. Discussed with Wangda