### PR TITLE
test: add throughput tracking to rlsim

### DIFF
--- a/examples/rl_sim_cpp/main.cc
+++ b/examples/rl_sim_cpp/main.cc
@@ -35,10 +35,10 @@ po::variables_map process_cmd_line(const int argc, char** argv)
       "Run in slates mode")("ca", po::value<bool>()->default_value(false), "Run in continuous actions mode")(
       "multistep", po::value<bool>()->default_value(false), "Run in multistep mode")(
       "num_events", po::value<int>()->default_value(0), "Number of event series' to be sent. 0 is infinite.")(
-      "random_seed", po::value<uint64_t>()->default_value(rand()), "Random seed. Default is random")("delay",
-      po::value<int64_t>()->default_value(2000),
-      "Delay between events in ms")("quiet", po::bool_switch(), "Suppress logs")(
-      "random_ids", po::value<bool>()->default_value(true), "Use randomly generated Event IDs. Default is true");
+      "random_seed", po::value<uint64_t>()->default_value(rand()), "Random seed. Default is random")(
+      "delay", po::value<int64_t>()->default_value(2000), "Delay between events in ms")(
+      "quiet", po::bool_switch(), "Suppress logs")("random_ids", po::value<bool>()->default_value(true),
+      "Use randomly generated Event IDs. Default is true")("throughput", "print throughput stats");
 
   po::variables_map vm;
   store(parse_command_line(argc, argv, desc), vm);

--- a/examples/rl_sim_cpp/rl_sim.cc
+++ b/examples/rl_sim_cpp/rl_sim.cc
@@ -419,7 +419,7 @@ private:
   int _print_counter = 0;
 };
 
-reinforcement_learning::sender_factory_t::create_fn generate_create_func(const std::string& name)
+reinforcement_learning::sender_factory_t::create_fn wrap_sender_generate_for_throughput_sender(const std::string& name)
 {
   return [=](std::unique_ptr<reinforcement_learning::i_sender>& retval, const u::configuration& cfg,
              reinforcement_learning::error_callback_fn* error_cb, reinforcement_learning::i_trace* trace_logger,
@@ -473,17 +473,17 @@ int rl_sim::init_rl()
   if (_options.count("throughput") != 0u)
   {
     factory.register_type(reinforcement_learning::value::OBSERVATION_EH_SENDER,
-        generate_create_func(reinforcement_learning::value::OBSERVATION_EH_SENDER));
+        wrap_sender_generate_for_throughput_sender(reinforcement_learning::value::OBSERVATION_EH_SENDER));
     factory.register_type(reinforcement_learning::value::INTERACTION_EH_SENDER,
-        generate_create_func(reinforcement_learning::value::INTERACTION_EH_SENDER));
+        wrap_sender_generate_for_throughput_sender(reinforcement_learning::value::INTERACTION_EH_SENDER));
     factory.register_type(reinforcement_learning::value::EPISODE_EH_SENDER,
-        generate_create_func(reinforcement_learning::value::EPISODE_EH_SENDER));
+        wrap_sender_generate_for_throughput_sender(reinforcement_learning::value::EPISODE_EH_SENDER));
     factory.register_type(reinforcement_learning::value::OBSERVATION_HTTP_API_SENDER,
-        generate_create_func(reinforcement_learning::value::OBSERVATION_HTTP_API_SENDER));
+        wrap_sender_generate_for_throughput_sender(reinforcement_learning::value::OBSERVATION_HTTP_API_SENDER));
     factory.register_type(reinforcement_learning::value::INTERACTION_HTTP_API_SENDER,
-        generate_create_func(reinforcement_learning::value::INTERACTION_HTTP_API_SENDER));
+        wrap_sender_generate_for_throughput_sender(reinforcement_learning::value::INTERACTION_HTTP_API_SENDER));
     factory.register_type(reinforcement_learning::value::EPISODE_HTTP_API_SENDER,
-        generate_create_func(reinforcement_learning::value::EPISODE_HTTP_API_SENDER));
+        wrap_sender_generate_for_throughput_sender(reinforcement_learning::value::EPISODE_HTTP_API_SENDER));
     sender_factory = &factory;
   }
 

--- a/examples/rl_sim_cpp/rl_sim.cc
+++ b/examples/rl_sim_cpp/rl_sim.cc
@@ -399,8 +399,9 @@ protected:
       auto now = std::chrono::steady_clock::now();
       auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - _begin_time).count();
       std::ostringstream oss;
-      oss << _name << " throughput: " << _bytes_sent / elapsed << " bytes/s, " << _messages_sent / elapsed
-          << " messages/s, " << _bytes_sent << " total bytes, " << _messages_sent << " total messages." << std::endl;
+      oss << _name << " throughput: " << _bytes_sent / elapsed << " bytes/s, "
+          << static_cast<float>(_messages_sent) / elapsed << " messages/s, " << _bytes_sent << " total bytes, "
+          << _messages_sent << " total messages." << std::endl;
       TRACE_INFO(_trace, oss.str());
       _print_counter = 0;
     }


### PR DESCRIPTION
Should be used with settings like the following:

```json
{
  "trace.logger.level": "INFO",
  "trace.logger.implementation": "CONSOLE_TRACE_LOGGER",
  "thoughputsender.printinterval": 20,
  "interaction.queue.mode": "BLOCK",
  "observation.queue.mode": "BLOCK"
}
```

Example output:
```
INFO: INTERACTION_EH_SENDER throughput: 4087656 bytes/s, 20 messages/s, 4087656 total bytes, 20 total messages.

INFO: INTERACTION_EH_SENDER throughput: 2689117 bytes/s, 13.3333 messages/s, 8067352 total bytes, 40 total messages.

INFO: OBSERVATION_EH_SENDER throughput: 1359336 bytes/s, 6.66667 messages/s, 4078008 total bytes, 20 total messages.

INFO: INTERACTION_EH_SENDER throughput: 3038892 bytes/s, 15 messages/s, 12155568 total bytes, 60 total messages.

INFO: INTERACTION_EH_SENDER throughput: 3240056 bytes/s, 16 messages/s, 16200280 total bytes, 80 total messages.

INFO: OBSERVATION_EH_SENDER throughput: 1608964 bytes/s, 8 messages/s, 8044820 total bytes, 40 total messages.
```